### PR TITLE
SentencePiece enhancements for Bergamot

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -36,24 +36,22 @@ jobs:
       run: |
         # Wget retries downloading files and is faster than Invoke-WebRequest
         C:\msys64\usr\bin\wget.exe -nv ${{ env.MKL_URL }} -O mkl.zip
-        Expand-Archive -Force mkl.zip ${{ github.workspace }}/mkl
-        # Set the MKLROOT environment variable so that CMake can find MKL.
-        # GITHUB_WORKSPACE is an environment variable available on all
-        # GitHub-hosted runners
-        echo "::set-env name=MKLROOT::$env:GITHUB_WORKSPACE/mkl"
+        Expand-Archive -Force mkl.zip ${{ github.workspace }}\mkl
+        # Set MKLROOT environment variable so that CMake can find MKL
+        echo "MKLROOT=${{ github.workspace }}\mkl" | Out-File -FilePath $env:GITHUB_ENV  -Encoding utf8 -Append
       shell: powershell
 
     - name: Install CUDA
       run: |
         .\scripts\ci\install_cuda_windows.ps1 "10.2"
-        # Set path to CUDA for subsequent steps so that CMake can find it
-        echo "::set-env name=CUDA_PATH::$env:CUDA_PATH"
-        echo "::add-path::$env:CUDA_PATH/bin"
+        # Set CUDA_PATH environment variable so that CMake can find CUDA
+        echo "CUDA_PATH=$env:CUDA_PATH" | Out-File -FilePath $env:GITHUB_ENV  -Encoding utf8 -Append
+        echo "$env:CUDA_PATH/bin"       | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       shell: powershell
       if: matrix.gpu == true
 
     - name: Prepare vcpkg
-      uses: lukka/run-vcpkg@v2
+      uses: lukka/run-vcpkg@v4
       with:
         vcpkgArguments: protobuf
         vcpkgGitCommitId: 6185aa76504a5025f36754324abf307cc776f3da
@@ -62,7 +60,7 @@ jobs:
 
     # Windows CUDA builds use USE_NCCL=off due to compilation errors.
     - name: Build Debug
-      uses: lukka/run-cmake@v2
+      uses: lukka/run-cmake@v3
       with:
         buildDirectory: ${{ github.workspace }}/build/Debug
         cmakeAppendedArgs: '-G Ninja
@@ -91,7 +89,7 @@ jobs:
     # https://github.com/actions/virtual-environments/blob/main/images/win/Windows2019-Readme.md#boost
     # (not used yet)
     - name: Build Release
-      uses: lukka/run-cmake@v2
+      uses: lukka/run-cmake@v3
       with:
         buildDirectory: ${{ github.workspace }}/build/
         cmakeAppendedArgs: '-G Ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,7 +228,7 @@ endif()
 # Downloading SentencePiece if requested and set to compile with it.
 # Requires all the dependencies imposed by SentencePiece
 if(USE_SENTENCEPIECE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_SENTENCEPIECE")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_SENTENCEPIECE -D_USE_INTERNAL_STRING_VIEW")
   LIST(APPEND CUDA_NVCC_FLAGS -DUSE_SENTENCEPIECE; )
   set(EXT_LIBS ${EXT_LIBS} sentencepiece sentencepiece_train)
 endif()

--- a/scripts/ci/install_cuda_windows.ps1
+++ b/scripts/ci/install_cuda_windows.ps1
@@ -118,4 +118,4 @@ if (!$?) {
 $CUDA_PATH = "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$($CUDA_MAJOR).$($CUDA_MINOR)"
 # Set environmental variables in this session
 $env:CUDA_PATH = "$($CUDA_PATH)"
-Write-Output "CUDA_PATH $($CUDA_PATH)"
+Write-Output "CUDA_PATH= $($CUDA_PATH)"

--- a/src/3rd_party/half_float/umHalf.inl
+++ b/src/3rd_party/half_float/umHalf.inl
@@ -45,6 +45,12 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	#pragma intrinsic(_BitScanReverse)
 #endif
 
+#if __cplusplus >= 201703L
+#define __SWITCHED_REGISTER
+#else
+#define __SWITCHED_REGISTER register
+#endif
+
 // ------------------------------------------------------------------------------------------------
 inline HalfFloat::HalfFloat(float other)
 {
@@ -344,7 +350,7 @@ inline HalfFloat operator+ (HalfFloat one, HalfFloat two)
 
 	// compute the difference between the two exponents. shifts with negative
 	// numbers are undefined, thus we need two code paths
-	register int expDiff = one.IEEE.Exp - two.IEEE.Exp;
+	__SWITCHED_REGISTER int expDiff = one.IEEE.Exp - two.IEEE.Exp;
 
 	if (0 == expDiff)
 	{

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,9 +4,11 @@ include_directories(.)
 include_directories(3rd_party)
 include_directories(3rd_party/SQLiteCpp/include)
 include_directories(3rd_party/sentencepiece)
+include_directories(3rd_party/sentencepiece/third_party/protobuf-lite)
 include_directories(3rd_party/fbgemm/include)
 include_directories(3rd_party/intgemm)
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/3rd_party/intgemm)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/3rd_party)
 include_directories(${CMAKE_BINARY_DIR}/local/include)
 
 set(MARIAN_SOURCES

--- a/src/data/sentencepiece_vocab.cpp
+++ b/src/data/sentencepiece_vocab.cpp
@@ -216,20 +216,20 @@ public:
       words.push_back(getEosId());
     return words;
   }
-  
-  Words encodePreservingSource(const string_view& line, 
-                               std::vector<string_view> &alignments,
+
+  Words encodeWithByteRanges(const string_view& line,
+                               std::vector<string_view> &byteRanges,
                                bool addEOS, bool inference) const override {
     sentencepiece::SentencePieceText spt;
     spm_->Encode(line, &spt);
 
-    Words words; 
+    Words words;
     words.reserve(spt.pieces().size() + addEOS);
     for(auto piece: spt.pieces()){
       Word word = Word::fromWordIndex(piece.id());
       words.push_back(word);
-      string_view alignment = line.substr(piece.begin(), piece.end() - piece.begin());
-      alignments.push_back(alignment);
+      string_view byteRange = line.substr(piece.begin(), piece.end() - piece.begin());
+      byteRanges.push_back(byteRange);
     }
 
     if (addEOS){

--- a/src/data/sentencepiece_vocab.cpp
+++ b/src/data/sentencepiece_vocab.cpp
@@ -225,7 +225,7 @@ public:
 
     Words words;
     words.reserve(spt.pieces().size() + addEOS);
-    for(auto piece: spt.pieces()){
+    for(auto piece : spt.pieces()) {
       Word word = Word::fromWordIndex(piece.id());
       words.push_back(word);
       string_view byteRange = line.substr(piece.begin(), piece.end() - piece.begin());

--- a/src/data/sentencepiece_vocab.cpp
+++ b/src/data/sentencepiece_vocab.cpp
@@ -1,9 +1,5 @@
 #include "data/vocab_base.h"
-
-#ifdef USE_SENTENCEPIECE
-#include "sentencepiece/src/sentencepiece_processor.h"
-#include "sentencepiece/src/sentencepiece_trainer.h"
-#endif
+#include "sentencepiece_vocab.h"
 
 #include "common/config.h"
 #include "common/options.h"
@@ -219,6 +215,28 @@ public:
 
     if(addEOS)
       words.push_back(getEosId());
+    return words;
+  }
+  
+  Words encodePreservingSource(const string_view& line, 
+                               std::vector<string_view> &alignments,
+                               bool addEOS, bool inference) const override {
+    sentencepiece::SentencePieceText spt;
+    spm_->Encode(line, &spt);
+
+    Words words; 
+    words.reserve(spt.pieces().size() + addEOS);
+    for(auto piece: spt.pieces()){
+      Word word = Word::fromWordIndex(piece.id());
+      words.push_back(word);
+      string_view alignment = line.substr(piece.begin(), piece.end() - piece.begin());
+      alignments.push_back(alignment);
+    }
+
+    if (addEOS){
+      words.push_back(getEosId());
+    }
+
     return words;
   }
 

--- a/src/data/sentencepiece_vocab.cpp
+++ b/src/data/sentencepiece_vocab.cpp
@@ -1,6 +1,5 @@
-#include "data/vocab_base.h"
 #include "sentencepiece_vocab.h"
-
+#include "data/vocab_base.h"
 #include "common/config.h"
 #include "common/options.h"
 #include "common/logging.h"

--- a/src/data/sentencepiece_vocab.h
+++ b/src/data/sentencepiece_vocab.h
@@ -1,5 +1,11 @@
 #ifdef USE_SENTENCEPIECE
 
+/* This should be the only place this warning is suppressed to get Windows build working. 
+ * Protobuf dependency creates W4100, which cannot be modified.
+ */
+
+#pragma warning(disable : 4100)
+
 #include "sentencepiece/src/sentencepiece_processor.h"
 #include "sentencepiece/src/sentencepiece_trainer.h"
 

--- a/src/data/sentencepiece_vocab.h
+++ b/src/data/sentencepiece_vocab.h
@@ -1,0 +1,22 @@
+
+
+#ifdef USE_SENTENCEPIECE
+
+namespace sentencepiece { class SentencePieceText; }
+#include "sentencepiece/src/sentencepiece_processor.h"
+#include "sentencepiece/src/sentencepiece_trainer.h"
+/* https://github.com/google/googletest/issues/1063#issuecomment-332518392 */	
+#if __GNUC__ >= 5	
+// Disable GCC 5's -Wsuggest-override warnings in gtest	
+# pragma GCC diagnostic push	
+# pragma GCC diagnostic ignored "-Wsuggest-override"	
+#endif	
+/* Current inclusion of SentencePiece structures assume builtin-protobuf hard. 
+ * Future TODO: Make it work with standard protobuf as well.
+ * */
+#include "sentencepiece/src/builtin_pb/sentencepiece.pb.h"	
+#if __GNUC__ >= 5	
+# pragma GCC diagnostic pop	
+#endif	
+
+#endif

--- a/src/data/sentencepiece_vocab.h
+++ b/src/data/sentencepiece_vocab.h
@@ -1,20 +1,20 @@
-
-
 #ifdef USE_SENTENCEPIECE
 
-namespace sentencepiece { class SentencePieceText; }
 #include "sentencepiece/src/sentencepiece_processor.h"
 #include "sentencepiece/src/sentencepiece_trainer.h"
+
 /* https://github.com/google/googletest/issues/1063#issuecomment-332518392 */	
 #if __GNUC__ >= 5	
 // Disable GCC 5's -Wsuggest-override warnings in gtest	
 # pragma GCC diagnostic push	
 # pragma GCC diagnostic ignored "-Wsuggest-override"	
 #endif	
+
 /* Current inclusion of SentencePiece structures assume builtin-protobuf hard. 
  * Future TODO: Make it work with standard protobuf as well.
  * */
 #include "sentencepiece/src/builtin_pb/sentencepiece.pb.h"	
+
 #if __GNUC__ >= 5	
 # pragma GCC diagnostic pop	
 #endif	

--- a/src/data/types.h
+++ b/src/data/types.h
@@ -2,12 +2,20 @@
 
 #include "common/definitions.h"
 
+/* absl::string_view is a type used within the generic vocab implementation.
+ * However, currently included from within sentencepiece to avoid an extra
+ * dependency. 
+ */
+
+#include "sentencepiece/third_party/absl/strings/string_view.h"
+
 #include <cstdint>
 #include <cstdlib>
 #include <string>
 #include <unordered_map>
 #include <vector>
 #include <iterator>
+
 
 namespace marian {
 
@@ -54,6 +62,8 @@ const std::string DEFAULT_UNK_STR = "<unk>";
 // alternatively accepted names in Yaml dictionaries for ids 0 and 1, resp.
 const std::string NEMATUS_EOS_STR = "eos";
 const std::string NEMATUS_UNK_STR = "UNK";
+
+typedef absl::string_view string_view;
 
 }  // namespace marian
 

--- a/src/data/types.h
+++ b/src/data/types.h
@@ -16,7 +16,6 @@
 #include <vector>
 #include <iterator>
 
-
 namespace marian {
 
 // Type for all vocabulary items, based on IndexType

--- a/src/data/vocab.cpp
+++ b/src/data/vocab.cpp
@@ -113,11 +113,11 @@ Words Vocab::encode(const std::string& line,
   return vImpl_->encode(line, addEOS, inference);
 }
 
-Words Vocab::encodePreservingSource(const string_view &line,
-        std::vector<string_view> &alignments,
+Words Vocab::encodeWithByteRanges(const string_view &line,
+        std::vector<string_view> &byteRanges,
               bool addEOS,
               bool inference) const {
-  return vImpl_->encodePreservingSource(line, alignments, addEOS, inference);
+  return vImpl_->encodeWithByteRanges(line, byteRanges, addEOS, inference);
 }
 
 // convert sequence of token ids to single line, can perform detokenization

--- a/src/data/vocab.cpp
+++ b/src/data/vocab.cpp
@@ -114,9 +114,9 @@ Words Vocab::encode(const std::string& line,
 }
 
 Words Vocab::encodeWithByteRanges(const string_view &line,
-        std::vector<string_view> &byteRanges,
-              bool addEOS,
-              bool inference) const {
+                                  std::vector<string_view> &byteRanges,
+                                  bool addEOS,
+                                  bool inference) const {
   return vImpl_->encodeWithByteRanges(line, byteRanges, addEOS, inference);
 }
 

--- a/src/data/vocab.cpp
+++ b/src/data/vocab.cpp
@@ -113,6 +113,13 @@ Words Vocab::encode(const std::string& line,
   return vImpl_->encode(line, addEOS, inference);
 }
 
+Words Vocab::encodePreservingSource(const string_view &line,
+        std::vector<string_view> &alignments,
+              bool addEOS,
+              bool inference) const {
+  return vImpl_->encodePreservingSource(line, alignments, addEOS, inference);
+}
+
 // convert sequence of token ids to single line, can perform detokenization
 std::string Vocab::decode(const Words& sentence,
                     bool ignoreEOS) const {

--- a/src/data/vocab.h
+++ b/src/data/vocab.h
@@ -5,6 +5,7 @@
 #include "common/options.h"
 #include "common/file_stream.h"
 
+
 namespace marian {
 
 class IVocab;
@@ -49,6 +50,11 @@ public:
   Words encode(const std::string& line,
                bool addEOS = true,
                bool inference = false) const;
+  
+  Words encodePreservingSource(const string_view &line, 
+                               std::vector<string_view> &alignments,
+                               bool addEOS=true, 
+                               bool inference=false) const;
 
   // convert sequence of token ids to single line, can perform detokenization
   std::string decode(const Words& sentence,

--- a/src/data/vocab.h
+++ b/src/data/vocab.h
@@ -49,11 +49,11 @@ public:
   Words encode(const std::string& line,
                bool addEOS = true,
                bool inference = false) const;
-  
-  Words encodePreservingSource(const string_view &line, 
-                               std::vector<string_view> &alignments,
-                               bool addEOS=true, 
-                               bool inference=false) const;
+
+  Words encodeWithByteRanges(const string_view &line,
+                               std::vector<string_view> &byteRanges,
+                               bool addEOS = true,
+                               bool inference = false) const;
 
   // convert sequence of token ids to single line, can perform detokenization
   std::string decode(const Words& sentence,

--- a/src/data/vocab.h
+++ b/src/data/vocab.h
@@ -5,7 +5,6 @@
 #include "common/options.h"
 #include "common/file_stream.h"
 
-
 namespace marian {
 
 class IVocab;

--- a/src/data/vocab_base.h
+++ b/src/data/vocab_base.h
@@ -31,6 +31,13 @@ public:
   virtual Words encode(const std::string& line,
                        bool addEOS = true,
                        bool inference = false) const = 0;
+  
+  virtual Words encodePreservingSource(const string_view &, 
+                                       std::vector<string_view> &,  
+                                       bool, 
+                                       bool) const {
+    ABORT("encodePreservingSource(...) is not implemented for this VocabType.");
+  }
 
   virtual std::string decode(const Words& sentence,
                              bool ignoreEos = true) const = 0;

--- a/src/data/vocab_base.h
+++ b/src/data/vocab_base.h
@@ -31,12 +31,12 @@ public:
   virtual Words encode(const std::string& line,
                        bool addEOS = true,
                        bool inference = false) const = 0;
-  
-  virtual Words encodePreservingSource(const string_view &, 
-                                       std::vector<string_view> &,  
-                                       bool, 
-                                       bool) const {
-    ABORT("encodePreservingSource(...) is not implemented for this VocabType.");
+
+  virtual Words encodeWithByteRanges(const string_view & /*line*/,
+                                       std::vector<string_view> & /*byteRanges*/,
+                                       bool /*addEOS*/,
+                                       bool /*inference*/) const {
+    ABORT("encodeWithByteRanges(...) is not implemented for this VocabType.");
   }
 
   virtual std::string decode(const Words& sentence,

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ if(NOT MSVC)
       prod
       cli
       pooling
+      sentencepiece_norm
   )
 
   foreach(test ${APP_TESTS})

--- a/src/tests/sentencepiece_norm.cpp
+++ b/src/tests/sentencepiece_norm.cpp
@@ -1,9 +1,9 @@
 #include "marian.h"
 
+#include "common/cli_helper.h"
+#include "common/cli_wrapper.h"
 #include "common/definitions.h"
 #include "common/options.h"
-#include "common/cli_wrapper.h"
-#include "common/cli_helper.h"
 #include "data/vocab.h"
 
 #include <iostream>
@@ -12,8 +12,7 @@
 using namespace marian;
 using namespace marian::cli;
 
-
-int main(int argc, char **argv){
+int main(int argc, char **argv) {
   auto options = New<Options>();
 
   YAML::Node config;
@@ -30,29 +29,26 @@ int main(int argc, char **argv){
 
   std::string line;
   bool addEOS{true}, inference{true};
-  while(std::getline(std::cin, line)){
-      std::vector<string_view> alignments;
-      auto words = vocab->encodePreservingSource(line, 
-                                                 alignments, 
-                                                 addEOS, 
-                                                 inference);
-      bool first = true;
+  while(std::getline(std::cin, line)) {
+    std::vector<string_view> byteRanges;
+    auto words = vocab->encodeWithByteRanges(line, byteRanges, addEOS, inference);
+    bool first = true;
 
-      /*
-       * alignments are constructed from ByteRanges. If the ByteRanges coming
-       * out of SentencePiece are correct, expected result is sourceToken that a
-       * word corresponding points to.
-       */
+    // If the ByteRanges coming out of SentencePiece are correct, expected
+    // result is sourceToken that a word corresponding points to. The output
+    // here is compared to an expected output containing unnormalized strings
+    // and matches, test passes. Testing requires a SentencePiece model, and
+    // hence designed as a test-app with tests in marian-regression-tests.
 
-      for(auto sourceView: alignments){ 
-          if(not first){
-              std::cout << " ";
-              first = false;
-          }
-          std::cout << sourceView;
-      } 
-      std::cout << std::endl;
-  } 
+    for(auto &sourceView : byteRanges) {
+      if(not first) {
+        std::cout << " ";
+        first = false;
+      }
+      std::cout << sourceView;
+    }
+    std::cout << std::endl;
+  }
 
-  return 0; 
+  return 0;
 }

--- a/src/tests/sentencepiece_norm.cpp
+++ b/src/tests/sentencepiece_norm.cpp
@@ -1,0 +1,58 @@
+#include "marian.h"
+
+#include "common/definitions.h"
+#include "common/options.h"
+#include "common/cli_wrapper.h"
+#include "common/cli_helper.h"
+#include "data/vocab.h"
+
+#include <iostream>
+#include <string>
+
+using namespace marian;
+using namespace marian::cli;
+
+
+int main(int argc, char **argv){
+  auto options = New<Options>();
+
+  YAML::Node config;
+  auto w = New<CLIWrapper>(config);
+  w->add<std::string>("-v,--vocab", "Path to vocab file");
+
+  w->parse(argc, argv);
+  options->merge(config);
+
+  auto vocabPath = options->get<std::string>("vocab");
+  size_t batchIndex = 0;
+  auto vocab = New<Vocab>(options, batchIndex);
+  vocab->load(vocabPath);
+
+  std::string line;
+  bool addEOS{true}, inference{true};
+  while(std::getline(std::cin, line)){
+      std::vector<string_view> alignments;
+      auto words = vocab->encodePreservingSource(line, 
+                                                 alignments, 
+                                                 addEOS, 
+                                                 inference);
+      bool first = true;
+
+      /*
+       * alignments are constructed from ByteRanges. If the ByteRanges coming
+       * out of SentencePiece are correct, expected result is sourceToken that a
+       * word corresponding points to.
+       */
+
+      for(auto sourceView: alignments){ 
+          if(not first){
+              std::cout << " ";
+              first = false;
+          }
+          std::cout << sourceView;
+      } 
+      std::cout << std::endl;
+  } 
+
+  return 0; 
+}


### PR DESCRIPTION
The following is what's essentially getting added.

```cpp
void SentencePieceVocab::encodeAsSentencePieceText(const std::string& line,
                                                   sentencepiece::SentencePieceText& spt) const {
  spm_->Encode(line, &spt);
}
```

But I need compiler to know `SentencePieceVocab` for using `tryAs` for more than `FactoredVocab`:

```cpp
sentencepiece::SentencePieceText Tokenizer::tokenize(std::string const &snt) {
  // TODO(jerin): Bunch of hardcode here, 1, 0, need to get rid off somehow.
  auto vImpl = vocabs_[0]->tryAs<marian::SentencePieceVocab>();
  sentencepiece::SentencePieceText spt;
  vImpl->encodeAsSentencePieceText(snt, spt);
  return spt;
}
```

Therefore `sentencepiece_vocab.cpp` -> `sentencepiece_vocab.h` + `sentencepiece_vocab.cpp`.