### PR TITLE
Adding decodeWithByteRanges: string_views into translated-text

### DIFF
--- a/src/data/vocab.cpp
+++ b/src/data/vocab.cpp
@@ -113,26 +113,34 @@ Words Vocab::encode(const std::string& line,
   return vImpl_->encode(line, addEOS, inference);
 }
 
+// same as Vocab::encode(...) above, but loads string_views corresponding to
+// each word into byteRanges. string_views refer to line and are valid only if
+// line is alive in scope. Useful in cases where the constituent word or
+// subword units need to be tracked to the source string. e.g: WordAlignments,
+// placing translations back into a structured text like HTML. Absent this
+// functionality, the mapping is lost while normalizing steps in preprocessing.
 Words Vocab::encodeWithByteRanges(const string_view &line,
                                   std::vector<string_view> &byteRanges,
-                                  bool addEOS,
-                                  bool inference) const {
-  return vImpl_->encodeWithByteRanges(line, byteRanges, addEOS, inference);
+                                  bool addEOS, bool inference) const {
+    return vImpl_->encodeWithByteRanges(line, byteRanges, addEOS, inference);
 }
 
-void Vocab::decodeWithByteRanges(const Words &sentence,
-                                    std::string &line,
-                                    std::vector<string_view> &byteRanges,
-                                    bool ignoreEOS)
-                                    const {
-  vImpl_->decodeWithByteRanges(sentence, line, byteRanges, ignoreEOS);
-}
 
 // convert sequence of token ids to single line, can perform detokenization
 std::string Vocab::decode(const Words& sentence,
                     bool ignoreEOS) const {
   return vImpl_->decode(sentence, ignoreEOS);
 }
+
+// same as Vocab::decode(...) above, except moves the decoded string into line
+// and loads the constituent word byteRanges into byteRanges. Useful for
+// converting WordAlignments to point between source and target units.
+
+void Vocab::decodeWithByteRanges(const Words &sentence,
+                                 std::string &line,
+                                 std::vector<string_view> &byteRanges,
+                                 bool ignoreEOS) const {
+    vImpl_->decodeWithByteRanges(sentence, line, byteRanges, ignoreEOS); }
 
 // convert sequence of token its to surface form (incl. removng spaces, applying factors)
 // for in-process BLEU validation

--- a/src/data/vocab.cpp
+++ b/src/data/vocab.cpp
@@ -120,6 +120,14 @@ Words Vocab::encodeWithByteRanges(const string_view &line,
   return vImpl_->encodeWithByteRanges(line, byteRanges, addEOS, inference);
 }
 
+void Vocab::decodeWithByteRanges(const Words &sentence,
+                                    std::string &line,
+                                    std::vector<string_view> &byteRanges,
+                                    bool ignoreEOS)
+                                    const {
+  vImpl_->decodeWithByteRanges(sentence, line, byteRanges, ignoreEOS);
+}
+
 // convert sequence of token ids to single line, can perform detokenization
 std::string Vocab::decode(const Words& sentence,
                     bool ignoreEOS) const {

--- a/src/data/vocab.h
+++ b/src/data/vocab.h
@@ -55,6 +55,11 @@ public:
                                bool addEOS = true,
                                bool inference = false) const;
 
+  void decodeWithByteRanges(const Words & sentence,
+                               std::string & line,
+                               std::vector<string_view> &byteRanges,
+                               bool ignoreEOS = true) const;
+
   // convert sequence of token ids to single line, can perform detokenization
   std::string decode(const Words& sentence,
                      bool ignoreEOS = true) const;

--- a/src/data/vocab_base.h
+++ b/src/data/vocab_base.h
@@ -39,6 +39,15 @@ public:
     ABORT("encodeWithByteRanges(...) is not implemented for this VocabType.");
   }
 
+  virtual void decodeWithByteRanges(const Words & /*sentence*/,
+                                       std::string & /*line*/,
+                                       std::vector<string_view> & /*byteRanges*/,
+                                       bool /*ignoreEOS*/)
+                                       const {
+    ABORT("decodeWithByteRanges(...) is not implemented for this VocabType.");
+  }
+
+
   virtual std::string decode(const Words& sentence,
                              bool ignoreEos = true) const = 0;
   virtual std::string surfaceForm(const Words& sentence) const = 0;


### PR DESCRIPTION
Attempting to solve https://github.com/browsermt/bergamot-translator/issues/25. Might be useful for https://github.com/marian-nmt/marian-dev/issues/775 (?)

Changes test to accommodate the decoded string_views as well. The square-brackets indicate annotations using string_views, constructed by [src/tests/sentencepiece_norm.cpp](https://github.com/browsermt/marian-dev/blob/9d5d0d74ffbbfcd9cdfe097f9dfe9e46d929ef86/src/tests/sentencepiece_norm.cpp). The test previously for `encodeWithByteRanges` is modified to include `decodeWithByteRanges` as well. Once the expected is set to the output, this regression-tests can be modified as well.

<details>
  <summary>Input Text </summary>
  
```
Äffin
Henry IV
Ç
가
ℌℍ
①
︷
i⁹
¼
```

</details>

<details>
  <summary>Output </summary>
  <p>
  
```
Original: [Ä][ff][in]
Decoded: [Ä][ff][in]
Original: [Henry][ IV]
Decoded: [Henry][ IV]
Original: [Ç]
Decoded: [Ç]
Original: [][가]
Decoded: [][ ⁇ ]
Original: [ℌ][ℍ]
Decoded: [H][H]
Original: [①]
Decoded: [1]
Original: [][︷]
Decoded: [][ ⁇ ]
Original: [i][⁹]
Decoded: [i][9]
Original: [][¼]
Decoded: [][1⁄4]
```

</p>
</details>

Requesting review.