### PR TITLE
Remove trailing slash from intgemm submodule gitmodules config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,7 +16,7 @@
 	branch = master
 [submodule "src/3rd_party/intgemm"]
 	path = src/3rd_party/intgemm
-	url = https://github.com/kpu/intgemm/
+	url = https://github.com/kpu/intgemm
 [submodule "src/3rd_party/simple-websocket-server"]
 	path = src/3rd_party/simple-websocket-server
 	url = https://github.com/marian-nmt/Simple-WebSocket-Server


### PR DESCRIPTION
It caused issues in CircleCI, see https://github.com/mozilla/bergamot-translator/pull/1#issuecomment-781876515