### PR TITLE
[RFC]Ssse3 hardcode

### DIFF
--- a/src/common/aliases.cpp
+++ b/src/common/aliases.cpp
@@ -235,6 +235,9 @@ void ConfigParser::addAliases(cli::CLIWrapper& cli) {
      cli.alias("int8", "true", [&](YAML::Node& config) {
        config["gemm-precision"] = "int8";
      });
+     cli.alias("int8Alpha", "true", [&](YAML::Node& config) {
+       config["gemm-precision"] = "int8Alpha";
+     });
      cli.alias("int8shift", "true", [&](YAML::Node& config) {
        config["gemm-precision"] = "int8shift";
      });

--- a/src/common/binary.cpp
+++ b/src/common/binary.cpp
@@ -59,12 +59,14 @@ void loadItems(const void* current, std::vector<io::Item>& items, bool mapped) {
 
   for(int i = 0; i < numHeaders; ++i) {
     if(items[i].mapped) { // memory-mapped, hence only set pointer
-      ABORT_IF(isIntgemm(items[i].type), "mmap format not supported for intgemm matrices");
+      //ABORT_IF(isIntgemm(items[i].type), "mmap format not supported for intgemm matrices");
       items[i].ptr = get<char>(current, headers[i].dataLength);
     } else { // reading into item data
       uint64_t len = headers[i].dataLength;
       items[i].bytes.resize(len);
       const char* ptr = get<char>(current, len);
+      /* // This section of the code prepares the width on demand, however since WASM only supports up to SSSE3
+         // We want to have a static format
       if (matchType<intgemm8>(items[i].type)) {
         if (items[i].name.find("Wemb") != std::string::npos) { //HACK HACK HACK THAT HACKS WEMB QUANTIZATION
           items[i].type = Type::float32;
@@ -80,10 +82,10 @@ void loadItems(const void* current, std::vector<io::Item>& items, bool mapped) {
           cpu::integer::unquantizeWemb<Type::int16>(items[i], ptr);
         } else {
           cpu::integer::prepareAndTransposeB<Type::int16>(items[i], ptr);
-        }
-      } else {
-        std::copy(ptr, ptr + len, items[i].bytes.begin());
-      }
+        }*/
+      //} else {
+      std::copy(ptr, ptr + len, items[i].bytes.begin());
+      //}
     }
   }
 }

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -927,6 +927,8 @@ void ConfigParser::addSuboptionsIntgemm(cli::CLIWrapper& cli) {
       "Deprecated. Corresponds to --gemm-precision int16");
   cli.add<bool>("--int8",
       "Optimize speed even more aggressively sacrificing memory or precision by using 8bit integer GEMM with intgemm instead of floats. Only available on CPU. Corresponds to --gemm-precision int8");
+  cli.add<bool>("--int8Alpha",
+      "Use precomputed alphas for performing the 8bit multiplication. Corresponds to --gemm-precision int8Alpha");
   cli.add<bool>("--int8shift",
       "Use a faster, shifted integer 8bit GEMM implementation. Corresponds to --gemm-precision int8shift");
   cli.add<bool>("--int8shiftAlpha",
@@ -936,7 +938,7 @@ void ConfigParser::addSuboptionsIntgemm(cli::CLIWrapper& cli) {
   cli.add<bool>("--int8shiftAlphaAll",
       "Use a faster, shifted integer 8bit GEMM implementation even for matrices that don't have a bias, with precomputed alphas. Should be the fastest option. Corresponds to --gemm-precision int8shiftAlphaAll");
   cli.add<std::string>("--gemm-precision",
-      "Use lower precision for the GEMM operations only. Supported values: float32, int16, int8, int8shift, int8shiftAlpha, int8shiftAll, int8shiftAlphaAll", "float32");
+      "Use lower precision for the GEMM operations only. Supported values: float32, int16, int8, int8Alpha, int8shift, int8shiftAlpha, int8shiftAll, int8shiftAlphaAll", "float32");
   cli.add<bool>("--dump-quantmult",
       "Dump the quantization multipliers of activation matrices during an avarage run. To be used to precompute alphas for ---gemm-precision int8shiftAlpha or int8shiftAlphaAll.");
   // clang-format on

--- a/src/graph/expression_graph.h
+++ b/src/graph/expression_graph.h
@@ -309,8 +309,6 @@ public:
     dot.close();
   }
 
-private:
-
   // Find the named parameter and its typed parent parameter object (params) and return both.
   // If the parameter is not found return the parent parameter object that the parameter should be added to.
   // Return [nullptr, nullptr] if no matching parent parameter object exists. 
@@ -340,6 +338,8 @@ private:
 
     return std::make_tuple(p, params);
   }
+
+private:
 
   Expr param(const std::string& pname,
              const Shape& shape,

--- a/src/tensors/cpu/backend.h
+++ b/src/tensors/cpu/backend.h
@@ -33,6 +33,9 @@ protected:
       setInt16(true);
     } else if (gemmPrecision == "int8") {
       setInt8(true);
+    } else if (gemmPrecision == "int8Alpha") {
+      setInt8(true);
+      setPrecomputedAlpha(true);
     } else if (gemmPrecision == "int8shift") {
       setInt8(true);
       setShifted(true);

--- a/src/tensors/cpu/integer_common.h
+++ b/src/tensors/cpu/integer_common.h
@@ -25,10 +25,12 @@ inline int cols(Shape& shape) { return shape[-1]; }
 inline int rows(Shape& shape) { return shape.elements() / cols(shape); }
 
 template<Type type> struct intgemm_;
-template <> struct intgemm_<Type::int8> {using width = intgemm::Int8;
+template <> struct intgemm_<Type::int8> {using width = intgemm::SSSE3::Kernels8;
+                                         using flexwidth = intgemm::Int8;
                                          using type = int8_t;
                                          constexpr static const Type intgemmType = Type::intgemm8;};
-template <> struct intgemm_<Type::int16> {using width = intgemm::Int16;
+template <> struct intgemm_<Type::int16> {using width = intgemm::SSE2::Kernels16;
+                                          using flexwidth = intgemm::Int16;
                                           using type = int16_t;
                                           constexpr static const Type intgemmType = Type::intgemm16;};
 

--- a/src/tensors/cpu/intgemm_interface.h
+++ b/src/tensors/cpu/intgemm_interface.h
@@ -272,7 +272,7 @@ public:
         auto quant_mult_b = this->child(3)->val();
 
         float unquant_mult = (-1)*((127.0f / *quant_mult_a->data())*(127.0f / *quant_mult_b->data()))/(127.0f); //Minus one to invert add_ps later on
-        intgemm::Int8Shift::PrepareBias((const int8_t *)b->data(), rows(b), cols(b), intgemm::callbacks::UnquantizeAndAddBiasAndWrite(unquant_mult, bias->data(), val_->data()));
+        intgemm_<Type::int8>::width::PrepareBias((const int8_t *)b->data(), rows(b), cols(b), intgemm::callbacks::UnquantizeAndAddBiasAndWrite(unquant_mult, bias->data(), val_->data()));
       }
       )};
 #else
@@ -303,7 +303,7 @@ public:
     auto quant_mult_b = this->child(2)->val();
 
     float unquant_mult = (-1)*((127.0f / *quant_mult_a->data())*(127.0f / *quant_mult_b->data()))/(127.0f); //Minus one to invert add_ps later on
-    intgemm::Int8Shift::PrepareBias((const int8_t *)b->data(), rows(b), cols(b), intgemm::callbacks::UnquantizeAndWrite(unquant_mult, val_->data()));
+    intgemm_<Type::int8>::width::PrepareBias((const int8_t *)b->data(), rows(b), cols(b), intgemm::callbacks::UnquantizeAndWrite(unquant_mult, val_->data()));
     )};
 #else
     return {NodeOp()};
@@ -410,7 +410,7 @@ public:
                                              cols(child(1)->val()),                                          /*child(2) is bias*/
                                              intgemm::callbacks::UnquantizeAndAddBiasAndWrite(unquant_mult, child(2)->val()->data(), val_->data()));
           } else {
-            intgemm::Int8Shift::Multiply(reinterpret_cast<int8_t *>(child(0)->val()->data()), /*A*/
+            intgemm_<Type::int8>::width::Multiply8Shift(reinterpret_cast<uint8_t *>(child(0)->val()->data()), /*A*/
                                   reinterpret_cast<int8_t *>(child(1)->val()->data()), /*B*/
                                   rows(child(0)->val()),
                                   cols(child(0)->val()),

--- a/src/tensors/cpu/intgemm_interface.h
+++ b/src/tensors/cpu/intgemm_interface.h
@@ -80,7 +80,17 @@ float quantMult_;
    return {NodeOp(
       quantMult_ = *child(1)->val()->data();
       typedef typename intgemm_<vtype>::type Integer;
-      if (isIntgemm(child(0)->value_type())) {
+      if (name() == "none" && false) { //@TODO fix loading WEMB from memory directly
+        std::cerr << "Name: " << name() << " shape: " << shape() << std::endl;
+        //auto param = child(0)->graph()->params()->get("F0::Wemb_quantised");
+        auto param = std::get<0>(child(0)->graph()->findParams("F0::Wemb_quantised", Type::intgemm8, true));
+        if (param) {
+          std::cerr << "NO null" << std::endl;
+        }
+        //auto param = child(0)->graph()->findParams("Wemb_quantised", Type::intgemm8);
+        val_ = param->val();
+        std::cerr << "Are we actually cheap?" << std::endl;
+      } else if (isIntgemm(child(0)->value_type())) {
         val_ = child(0)->val();
       } else {
         intgemm_<vtype>::width::PrepareB(child(0)->val()->data(), /*input*/


### PR DESCRIPTION
### Description
This pull request changes the intgemm binary file format to be directly in the SSSE3 architecture which is the only one supported by wasm. The advantage of this approach would be slightly lower memory consumption when loading the model and slightly faster loading as we don't need to reorder the matrices.

The disadvantage is that all binary formats currently need to be recreated and that we're making it very difficult to later on add AVX2 support without breaking the binary compatibility.