### PR TITLE
Add binary shortlist and converter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   and translation with options --tsv and --tsv-fields n.
 - Internal optional parameter in n-best list generation that skips empty hypotheses.
 - Quantized training (fixed point or log-based quantization) with --quantize-bits N command
+- Support for loading lexical shortlist from a binary blob
+- Integrate a shortlist converter (which can convert a text lexical shortlist to a binary shortlist) into marian-conv with --shortlist option
 
 ### Fixed
 - Segfault of spm_train when compiled with -DUSE_STATIC_LIBS=ON seems to have gone away with update to newer SentencePiece version.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -42,6 +42,7 @@ set(MARIAN_SOURCES
   data/corpus_sqlite.cpp
   data/corpus_nbest.cpp
   data/text_input.cpp
+  data/shortlist.cpp
 
   3rd_party/cnpy/cnpy.cpp
   3rd_party/ExceptionWithCallStack.cpp

--- a/src/command/marian_conv.cpp
+++ b/src/command/marian_conv.cpp
@@ -35,9 +35,7 @@ int main(int argc, char** argv) {
   }
 
   // shortlist conversion example:
-  // ./ marian-conv --shortlist lex.esen.s2t 100 100 0 \
-  //               --dump lex.esen.bin \
-  //               --vocabs vocab.esen.spm vocab.esen.spm
+  // ./marian-conv --shortlist lex.esen.s2t 100 100 0 --dump lex.esen.bin --vocabs vocab.esen.spm vocab.esen.spm
   if(options->hasAndNotEmpty("shortlist")){
     auto vocabPaths = options->get<std::vector<std::string>>("vocabs");
     auto dumpPath = options->get<std::string>("dump");

--- a/src/command/marian_conv.cpp
+++ b/src/command/marian_conv.cpp
@@ -18,7 +18,8 @@ int main(int argc, char** argv) {
     YAML::Node config; // @TODO: get rid of YAML::Node here entirely to avoid the pattern. Currently not fixing as it requires more changes to the Options object.
     auto cli = New<cli::CLIWrapper>(
         config,
-        "Convert a model in the .npz format and normal memory layout to a mmap-able binary model which could be in normal memory layout or packed memory layout",
+        "Convert a model in the .npz format and normal memory layout to a mmap-able binary model which could be in normal memory layout or packed memory layout\n"
+        "or convert a text lexical shortlist to a binary shortlist with {--shortlist,-s} option",
         "Allowed options",
         "Examples:\n"
         "  ./marian-conv -f model.npz -t model.bin --gemm-type packed16");

--- a/src/command/marian_conv.cpp
+++ b/src/command/marian_conv.cpp
@@ -4,7 +4,7 @@
 
 #include <sstream>
 
-
+#include "data/shortlist.h"
 #include "tensors/cpu/expression_graph_packable.h"
 #include "onnx/expression_graph_onnx_exporter.h"
 
@@ -26,10 +26,33 @@ int main(int argc, char** argv) {
     cli->add<std::string>("--to,-t", "Output model", "model.bin");
     cli->add<std::string>("--export-as", "Kind of conversion: marian-bin or onnx-{encode,decoder-step,decoder-init,decoder-stop}", "marian-bin");
     cli->add<std::string>("--gemm-type,-g", "GEMM Type to be used: float32, packed16, packed8avx2, packed8avx512, intgemm8, intgemm16", "float32");
-    cli->add<std::vector<std::string>>("--vocabs,-V", "Vocabulary file, required for ONNX export");
+    cli->add<std::vector<std::string>>("--vocabs,-V", "Vocabulary file, required for ONNX export and shortlist conversion");
+    cli->add<std::vector<std::string>>("--shortlist,-s", "Shortlist conversion: filePath firstNum bestNum threshold");
+    cli->add<std::string>("--dump,-d", "Binary shortlist dump path","lex.bin");
     cli->parse(argc, argv);
     options->merge(config);
   }
+
+  // shortlist conversion example:
+  // ./ marian-cov --shortlist lex.esen.s2t 100 100 0
+  //               --dump lex.esen.bin
+  //               --vocabs vocab.esen.spm vocab.esen.spm
+  if(options->hasAndNotEmpty("shortlist")){
+    auto vocabPaths = options->get<std::vector<std::string>>("vocabs");
+    auto dumpPath = options->get<std::string>("dump");
+
+    Ptr<Vocab> srcVocab = New<Vocab>(options, 0);
+    srcVocab->load(vocabPaths[0]);
+    Ptr<Vocab> trgVocab = New<Vocab>(options, 1);
+    trgVocab->load(vocabPaths[1]);
+
+    Ptr<const data::ShortlistGenerator> binaryShortlistGenerator
+        = New<data::BinaryShortlistGenerator>(options, srcVocab, trgVocab, 0, 1, vocabPaths[0] == vocabPaths[1]);
+    binaryShortlistGenerator->dump(dumpPath);
+    LOG(info, "Finished");
+    return 0;
+  }
+
   auto modelFrom = options->get<std::string>("from");
   auto modelTo = options->get<std::string>("to");
 

--- a/src/command/marian_conv.cpp
+++ b/src/command/marian_conv.cpp
@@ -35,8 +35,8 @@ int main(int argc, char** argv) {
   }
 
   // shortlist conversion example:
-  // ./ marian-cov --shortlist lex.esen.s2t 100 100 0
-  //               --dump lex.esen.bin
+  // ./ marian-conv --shortlist lex.esen.s2t 100 100 0 \
+  //               --dump lex.esen.bin \
   //               --vocabs vocab.esen.spm vocab.esen.spm
   if(options->hasAndNotEmpty("shortlist")){
     auto vocabPaths = options->get<std::vector<std::string>>("vocabs");

--- a/src/common/hash.h
+++ b/src/common/hash.h
@@ -10,11 +10,19 @@ template <class T> using hash = std::hash<T>;
 // This combinator is based on boost::hash_combine, but uses
 // std::hash as the hash implementation. Used as a drop-in
 // replacement for boost::hash_combine.
+template <class T, class HashType = std::size_t>
+inline void hash_combine(HashType& seed, T const& v) {
+  hash<T> hasher;
+  seed ^= static_cast<HashType>(hasher(v)) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+}
 
-template <class T>
-inline void hash_combine(std::size_t& seed, T const& v) {
-    hash<T> hasher;
-    seed ^= hasher(v) + 0x9e3779b9 + (seed<<6) + (seed>>2);
+// Hash a whole chunk of memory, mostly used for diagnostics
+template <class T, class HashType = std::size_t>
+inline HashType hashMem(const T* beg, size_t len) {
+  HashType seed = 0;
+  for(auto it = beg; it < beg + len; ++it)
+    hash_combine(seed, *it);
+  return seed;
 }
 
 }

--- a/src/data/shortlist.cpp
+++ b/src/data/shortlist.cpp
@@ -1,0 +1,396 @@
+#include "shortlist.h"
+#include <queue>
+
+namespace marian {
+namespace data {
+
+bool isBinaryShortlist(const std::string& fileName){
+  uint64_t magic;
+  io::InputFileStream in(fileName);
+  in.read((char*)(&magic), sizeof(magic));
+  return in && (magic == BINARY_SHORTLIST_MAGIC);
+}
+
+void LexicalShortlistGenerator::load(const std::string& fname) {
+  io::InputFileStream in(fname);
+
+  std::string src, trg;
+  float prob;
+  while(in >> trg >> src >> prob) {
+    // @TODO: change this to something safer other than NULL
+    if(src == "NULL" || trg == "NULL")
+      continue;
+
+    auto sId = (*srcVocab_)[src].toWordIndex();
+    auto tId = (*trgVocab_)[trg].toWordIndex();
+
+    if(data_.size() <= sId)
+      data_.resize(sId + 1);
+    data_[sId][tId] = prob;
+  }
+}
+
+void LexicalShortlistGenerator::prune(float threshold /* = 0.f*/) {
+  size_t i = 0;
+  for(auto& probs : data_) {
+    std::vector<std::pair<float, WordIndex>> sorter;
+    for(auto& it : probs)
+      sorter.emplace_back(it.second, it.first);
+
+    std::sort(
+        sorter.begin(), sorter.end(), std::greater<std::pair<float, WordIndex>>()); // sort by prob
+
+    probs.clear();
+    for(auto& it : sorter) {
+      if(probs.size() < bestNum_ && it.first > threshold)
+        probs[it.second] = it.first;
+      else
+        break;
+    }
+
+    ++i;
+  }
+}
+
+LexicalShortlistGenerator::LexicalShortlistGenerator(Ptr<Options> options,
+                                                     Ptr<const Vocab> srcVocab,
+                                                     Ptr<const Vocab> trgVocab,
+                                                     size_t srcIdx /* = 0 */,
+                                                     size_t /*trgIdx = 1 */,
+                                                     bool shared /*= false*/)
+    : options_(options),
+      srcVocab_(srcVocab),
+      trgVocab_(trgVocab),
+      srcIdx_(srcIdx),
+      shared_(shared) {
+  std::vector<std::string> vals = options_->get<std::vector<std::string>>("shortlist");
+
+  ABORT_IF(vals.empty(), "No path to filter path given");
+  std::string fname = vals[0];
+
+  firstNum_ = vals.size() > 1 ? std::stoi(vals[1]) : 100;
+  bestNum_ = vals.size() > 2 ? std::stoi(vals[2]) : 100;
+  float threshold = vals.size() > 3 ? std::stof(vals[3]) : 0;
+  std::string dumpPath = vals.size() > 4 ? vals[4] : "";
+  LOG(info,
+      "[data] Loading lexical shortlist as {} {} {} {}",
+      fname,
+      firstNum_,
+      bestNum_,
+      threshold);
+
+  // @TODO: Load and prune in one go.
+  load(fname);
+  prune(threshold);
+
+  if(!dumpPath.empty())
+    dump(dumpPath);
+}
+
+void LexicalShortlistGenerator::dump(const std::string& prefix) const {
+  // Dump top most frequent words from target vocabulary
+  LOG(info, "[data] Saving shortlist dump to {}", prefix + ".{top,dic}");
+  io::OutputFileStream outTop(prefix + ".top");
+  for(WordIndex i = 0; i < firstNum_ && i < trgVocab_->size(); ++i)
+    outTop << (*trgVocab_)[Word::fromWordIndex(i)] << std::endl;
+
+  // Dump translation pairs from dictionary
+  io::OutputFileStream outDic(prefix + ".dic");
+  for(WordIndex srcId = 0; srcId < data_.size(); srcId++) {
+    for(auto& it : data_[srcId]) {
+      auto trgId = it.first;
+      outDic << (*srcVocab_)[Word::fromWordIndex(srcId)] << "\t" << (*trgVocab_)[Word::fromWordIndex(trgId)] << std::endl;
+    }
+  }
+}
+
+Ptr<Shortlist> LexicalShortlistGenerator::generate(Ptr<data::CorpusBatch> batch) const {
+  auto srcBatch = (*batch)[srcIdx_];
+
+  // add firstNum most frequent words
+  std::unordered_set<WordIndex> indexSet;
+  for(WordIndex i = 0; i < firstNum_ && i < trgVocab_->size(); ++i)
+    indexSet.insert(i);
+
+  // add all words from ground truth
+  // for(auto i : trgBatch->data())
+  //  indexSet.insert(i.toWordIndex());
+
+  // collect unique words form source
+  std::unordered_set<WordIndex> srcSet;
+  for(auto i : srcBatch->data())
+    srcSet.insert(i.toWordIndex());
+
+  // add aligned target words
+  for(auto i : srcSet) {
+    if(shared_)
+      indexSet.insert(i);
+    for(auto& it : data_[i])
+      indexSet.insert(it.first);
+  }
+  // Ensure that the generated vocabulary items from a shortlist are a multiple-of-eight
+  // This is necessary until intgemm supports non-multiple-of-eight matrices.
+  // TODO better solution here? This could potentially be slow.
+  WordIndex i = static_cast<WordIndex>(firstNum_);
+  while (indexSet.size() % 8 != 0) {
+    indexSet.insert(i);
+    i++;
+  }
+
+  // turn into vector and sort (selected indices)
+  std::vector<WordIndex> indices(indexSet.begin(), indexSet.end());
+  std::sort(indices.begin(), indices.end());
+
+  return New<Shortlist>(indices);
+}
+
+void BinaryShortlistGenerator::contentCheck() {
+  bool failFlag = 0;
+  // The offset table has to be within the size of shortlists.
+  for(int i = 0; i < wordToOffsetSize_; i++)
+    failFlag |= wordToOffset_[i] >= shortListsSize_;
+  // The vocabulary indices have to be within the vocabulary size.
+  size_t vSize = trgVocab_->size();
+  for(int j = 0; j < shortListsSize_; j++)
+    failFlag |= shortLists_[j] >= vSize;
+  ABORT_IF(failFlag, "Error: shortlist indices are out of bounds");
+}
+
+// load shortlist from buffer
+void BinaryShortlistGenerator::load(const void* ptr_void, size_t blobSize, bool check /*= true*/) {
+  /* File layout:
+   * header
+   * wordToOffset array
+   * shortLists array
+   */
+  ABORT_IF(blobSize < sizeof(Header), "Shortlist length {} too short to have a header", blobSize);
+
+  const char *ptr = static_cast<const char*>(ptr_void);
+  const Header &header = *reinterpret_cast<const Header*>(ptr);
+  ptr += sizeof(Header);
+  ABORT_IF(header.magic != BINARY_SHORTLIST_MAGIC, "Incorrect magic in binary shortlist");
+
+  uint64_t expectedSize = sizeof(Header) + header.wordToOffsetSize * sizeof(uint64_t) + header.shortListsSize * sizeof(WordIndex);
+  ABORT_IF(expectedSize != blobSize, "Shortlist header claims file size should be {} but file is {}", expectedSize, blobSize);
+
+  if (check) {
+    uint64_t checksumActual = util::hashMem<uint64_t, uint64_t>(&header.firstNum, (blobSize - sizeof(header.magic) - sizeof(header.checksum)) / sizeof(uint64_t));
+    ABORT_IF(checksumActual != header.checksum, "checksum check failed: this binary shortlist is corrupted");
+  }
+
+  firstNum_ = header.firstNum;
+  bestNum_ = header.bestNum;
+  LOG(info, "[data] Lexical short list firstNum {} and bestNum {}", firstNum_, bestNum_);
+
+  wordToOffsetSize_ = header.wordToOffsetSize;
+  shortListsSize_ = header.shortListsSize;
+
+  // Offsets right after header.
+  wordToOffset_ = reinterpret_cast<const uint64_t*>(ptr);
+  ptr += wordToOffsetSize_ * sizeof(uint64_t);
+
+  shortLists_ = reinterpret_cast<const WordIndex*>(ptr);
+
+  // Verify offsets and vocab ids are within bounds if requested by user.
+  if(check)
+    contentCheck();
+}
+
+// load shortlist from file
+void BinaryShortlistGenerator::load(const std::string& filename, bool check /*=true*/) {
+  std::error_code error;
+  mmapMem_.map(filename, error);
+  ABORT_IF(error, "Error mapping file: {}", error.message());
+  load(mmapMem_.data(), mmapMem_.mapped_length(), check);
+}
+
+BinaryShortlistGenerator::BinaryShortlistGenerator(Ptr<Options> options,
+                                                   Ptr<const Vocab> srcVocab,
+                                                   Ptr<const Vocab> trgVocab,
+                                                   size_t srcIdx /*= 0*/,
+                                                   size_t /*trgIdx = 1*/,
+                                                   bool shared /*= false*/)
+    : options_(options),
+      srcVocab_(srcVocab),
+      trgVocab_(trgVocab),
+      srcIdx_(srcIdx),
+      shared_(shared) {
+
+  std::vector<std::string> vals = options_->get<std::vector<std::string>>("shortlist");
+  ABORT_IF(vals.empty(), "No path to shortlist file given");
+  std::string fname = vals[0];
+
+  if(isBinaryShortlist(fname)){
+    bool check = vals.size() > 1 ? std::stoi(vals[1]) : 1;
+    LOG(info, "[data] Loading binary shortlist as {} {}", fname, check);
+    load(fname, check);
+  }
+  else{
+    firstNum_ = vals.size() > 1 ? std::stoi(vals[1]) : 100;
+    bestNum_ = vals.size() > 2 ? std::stoi(vals[2]) : 100;
+    float threshold = vals.size() > 3 ? std::stof(vals[3]) : 0;
+    LOG(info, "[data] Importing text lexical shortlist as {} {} {} {}",
+        fname, firstNum_, bestNum_, threshold);
+    import(fname, threshold);
+  }
+}
+
+Ptr<Shortlist> BinaryShortlistGenerator::generate(Ptr<data::CorpusBatch> batch) const {
+  auto srcBatch = (*batch)[srcIdx_];
+  size_t srcVocabSize = srcVocab_->size();
+  size_t trgVocabSize = trgVocab_->size();
+
+  // Since V=trgVocab_->size() is not large, anchor the time and space complexity to O(V).
+  // Attempt to squeeze the truth tables into CPU cache
+  std::vector<bool> srcTruthTable(srcVocabSize, 0);  // holds selected source words
+  std::vector<bool> trgTruthTable(trgVocabSize, 0);  // holds selected target words
+
+  // add firstNum most frequent words
+  for(WordIndex i = 0; i < firstNum_ && i < trgVocabSize; ++i)
+    trgTruthTable[i] = 1;
+
+  // collect unique words from source
+  // add aligned target words: mark trgTruthTable[word] to 1
+  for(auto word : srcBatch->data()) {
+    WordIndex srcIndex = word.toWordIndex();
+    if(shared_)
+      trgTruthTable[srcIndex] = 1;
+    // If srcIndex has not been encountered, add the corresponding target words
+    if (!srcTruthTable[srcIndex]) {
+      for (uint64_t j = wordToOffset_[srcIndex]; j < wordToOffset_[srcIndex+1]; j++)
+        trgTruthTable[shortLists_[j]] = 1;
+      srcTruthTable[srcIndex] = 1;
+    }
+  }
+
+  // Due to the 'multiple-of-eight' issue, the following O(N) patch is inserted
+  size_t trgTruthTableOnes = 0;   // counter for no. of selected target words
+  for (size_t i = 0; i < trgVocabSize; i++) {
+    if(trgTruthTable[i])
+      trgTruthTableOnes++;
+  }
+
+  // Ensure that the generated vocabulary items from a shortlist are a multiple-of-eight
+  // This is necessary until intgemm supports non-multiple-of-eight matrices.
+  for (size_t i = firstNum_; i < trgVocabSize && trgTruthTableOnes%8!=0; i++){
+    if (!trgTruthTable[i]){
+      trgTruthTable[i] = 1;
+      trgTruthTableOnes++;
+    }
+  }
+
+  // turn selected indices into vector and sort (Bucket sort: O(V))
+  std::vector<WordIndex> indices;
+  for (WordIndex i = 0; i < trgVocabSize; i++) {
+    if(trgTruthTable[i])
+      indices.push_back(i);
+  }
+
+  return New<Shortlist>(indices);
+}
+
+void BinaryShortlistGenerator::dump(const std::string& fileName) const {
+  ABORT_IF(mmapMem_.is_open(),"No need to dump again");
+  LOG(info, "[data] Saving binary shortlist dump to {}", fileName);
+  std::vector<char> blob = generateBlob();
+  saveBlobToFile(blob,fileName);
+}
+
+void BinaryShortlistGenerator::import(const std::string& filename, double threshold) {
+  io::InputFileStream in(filename);
+  std::string src, trg;
+
+  // Read text file
+  std::vector<std::unordered_map<WordIndex, float>> srcTgtProbTable;
+  float prob;
+
+  while(in >> trg >> src >> prob) {
+    if(src == "NULL" || trg == "NULL")
+      continue;
+
+    auto sId = (*srcVocab_)[src].toWordIndex();
+    auto tId = (*trgVocab_)[trg].toWordIndex();
+    if(srcTgtProbTable.size() <= sId)
+      srcTgtProbTable.resize(sId + 1);
+    if(srcTgtProbTable[sId][tId] < prob)
+      srcTgtProbTable[sId][tId] = prob;
+  }
+
+  // Create priority queue and count
+  std::vector<std::priority_queue<std::pair<double, WordIndex>>> vpq;
+  uint64_t shortListSize = 0;
+
+  vpq.resize(srcTgtProbTable.size());
+  for(WordIndex sId = 0; sId < srcTgtProbTable.size(); sId++) {
+    uint64_t shortListSizeCurrent = 0;
+    for(auto entry : srcTgtProbTable[sId]) {
+      if (entry.first>=threshold) {
+        vpq[sId].push(std::make_pair(entry.second, entry.first));
+        if(shortListSizeCurrent < bestNum_)
+          shortListSizeCurrent++;
+      }
+    }
+    shortListSize += shortListSizeCurrent;
+  }
+
+  uint64_t wordToOffsetSize = vpq.size()+1;
+  uint64_t* wordToOffset = new uint64_t[wordToOffsetSize];
+  WordIndex* shortLists = new WordIndex[shortListSize];
+  WordIndex shortlistIdx = 0;
+  for(size_t i=0; i< wordToOffsetSize -1; i++) {
+    wordToOffset[i] = shortlistIdx;
+    for(int popcnt = 0; popcnt < bestNum_ && !vpq[i].empty(); popcnt++) {
+      shortLists[shortlistIdx] = vpq[i].top().second;
+      shortlistIdx++;
+      vpq[i].pop();
+    }
+  }
+  wordToOffset[wordToOffsetSize-1] = shortlistIdx;
+
+  // Sort word indices for each shortlist
+  for(int i = 1; i < wordToOffsetSize; i++) {
+    std::sort(&shortLists[wordToOffset[i-1]], &shortLists[wordToOffset[i]]);
+  }
+
+  wordToOffset_ = wordToOffset;
+  shortLists_ = shortLists;
+  wordToOffsetSize_ = wordToOffsetSize;
+  shortListsSize_ = shortListSize;
+}
+
+std::vector<char> BinaryShortlistGenerator::generateBlob() const{
+  // Build the body
+  std::vector<char> body;
+  body.insert(body.end(), (char *)&firstNum_, (char *)&firstNum_ + sizeof(uint64_t));
+  body.insert(body.end(), (char *)&bestNum_, (char *)&bestNum_ + sizeof(uint64_t));
+  body.insert(body.end(), (char *)&wordToOffsetSize_, (char *)&wordToOffsetSize_ + sizeof(uint64_t));
+  body.insert(body.end(), (char *)&shortListsSize_, (char *)&shortListsSize_ + sizeof(uint64_t));
+  body.insert(body.end(),
+              (char *)wordToOffset_,
+              (char *)wordToOffset_ + wordToOffsetSize_ * sizeof(uint64_t));
+  body.insert(body.end(),
+              (char *)shortLists_,
+              (char *)shortLists_ + shortListsSize_ * sizeof(uint32_t));
+
+  // Compute the checksum
+  uint64_t bodySize = body.size();
+  uint64_t checksum
+      = (uint64_t)util::hashMem<uint64_t>((uint64_t *)body.data(), bodySize / sizeof(uint64_t));
+
+  // Produce the blob with the header and the body
+  std::vector<char> blob;
+  blob.insert(blob.end(), (char *)&BINARY_SHORTLIST_MAGIC, (char *)&BINARY_SHORTLIST_MAGIC + sizeof(uint64_t));
+  blob.insert(blob.end(), (char *)&checksum, (char *)&checksum + sizeof(uint64_t));
+  blob.insert(blob.end(), body.begin(), body.end());
+
+  return blob;
+}
+
+void BinaryShortlistGenerator::saveBlobToFile(std::vector<char> blob,
+                                              const std::string& fileName) const {
+  io::OutputFileStream outTop(fileName);
+  outTop.write(blob.data(), blob.size());
+}
+
+}  // namespace data
+}  // namespace marian

--- a/src/data/shortlist.cpp
+++ b/src/data/shortlist.cpp
@@ -296,7 +296,6 @@ Ptr<Shortlist> BinaryShortlistGenerator::generate(Ptr<data::CorpusBatch> batch) 
 void BinaryShortlistGenerator::dump(const std::string& fileName) const {
   ABORT_IF(mmapMem_.is_open(),"No need to dump again");
   LOG(info, "[data] Saving binary shortlist dump to {}", fileName);
-//  std::vector<char> blob = generateBlob();
   saveBlobToFile(fileName);
 }
 
@@ -341,8 +340,8 @@ void BinaryShortlistGenerator::import(const std::string& filename, double thresh
   shortListsSize_ = shortListsSize;
 
   // Generate a binary blob
-  blob.resize(sizeof(Header) + wordToOffsetSize_ * sizeof(uint64_t) + shortListsSize_ * sizeof(WordIndex));
-  struct Header* pHeader = (struct Header *)blob.data();
+  blob_.resize(sizeof(Header) + wordToOffsetSize_ * sizeof(uint64_t) + shortListsSize_ * sizeof(WordIndex));
+  struct Header* pHeader = (struct Header *)blob_.data();
   pHeader->magic = BINARY_SHORTLIST_MAGIC;
   pHeader->firstNum = firstNum_;
   pHeader->bestNum = bestNum_;
@@ -366,7 +365,8 @@ void BinaryShortlistGenerator::import(const std::string& filename, double thresh
   for(int i = 1; i < wordToOffsetSize_; i++) {
     std::sort(&shortLists[wordToOffset[i-1]], &shortLists[wordToOffset[i]]);
   }
-  pHeader->checksum = (uint64_t)util::hashMem<uint64_t>((uint64_t *)blob.data()+2, blob.size()/sizeof(uint64_t)-2);
+  pHeader->checksum = (uint64_t)util::hashMem<uint64_t>((uint64_t *)blob_.data()+2,
+                                                        blob_.size()/sizeof(uint64_t)-2);
 
   wordToOffset_ = wordToOffset;
   shortLists_ = shortLists;
@@ -374,7 +374,7 @@ void BinaryShortlistGenerator::import(const std::string& filename, double thresh
 
 void BinaryShortlistGenerator::saveBlobToFile(const std::string& fileName) const {
   io::OutputFileStream outTop(fileName);
-  outTop.write(blob.data(), blob.size());
+  outTop.write(blob_.data(), blob_.size());
 }
 
 }  // namespace data

--- a/src/data/shortlist.h
+++ b/src/data/shortlist.h
@@ -181,6 +181,7 @@ private:
   uint64_t shortListsSize_;
   const uint64_t *wordToOffset_;
   const WordIndex *shortLists_;
+  std::vector<char> blob_;  // binary blob
 
   struct Header {
     uint64_t magic; // BINARY_SHORTLIST_MAGIC
@@ -198,9 +199,7 @@ private:
   void load(const std::string& filename, bool check=true);
   // import text shortlist from file
   void import(const std::string& filename, double threshold);
-  // generate blob from vectors
-  std::vector<char> blob;
-
+  // save blob to file (called by dump)
   void saveBlobToFile(const std::string& filename) const;
 
 public:

--- a/src/data/shortlist.h
+++ b/src/data/shortlist.h
@@ -40,7 +40,6 @@ public:
     else
       return -1;                                          // return -1 if not found
   }
-
 };
 
 class ShortlistGenerator {
@@ -200,8 +199,9 @@ private:
   // import text shortlist from file
   void import(const std::string& filename, double threshold);
   // generate blob from vectors
-  std::vector<char> generateBlob() const;
-  void saveBlobToFile(std::vector<char> blob, const std::string& filename) const;
+  std::vector<char> blob;
+
+  void saveBlobToFile(const std::string& filename) const;
 
 public:
   BinaryShortlistGenerator(Ptr<Options> options,

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -59,9 +59,17 @@ public:
     trgVocab_->load(vocabs.back());
     auto srcVocab = corpus_->getVocabs()[0];
 
-    if(options_->hasAndNotEmpty("shortlist"))
-      shortlistGenerator_ = New<data::LexicalShortlistGenerator>(
-          options_, srcVocab, trgVocab_, 0, 1, vocabs.front() == vocabs.back());
+    if(options_->hasAndNotEmpty("shortlist")) {
+      auto slOptions = options_->get<std::vector<std::string>>("shortlist");
+      ABORT_IF(slOptions.empty(), "No path to shortlist file given");
+      std::string filename = slOptions[0];
+      if(data::isBinaryShortlist(filename))
+        shortlistGenerator_ = New<data::BinaryShortlistGenerator>(
+            options_, srcVocab, trgVocab_, 0, 1, vocabs.front() == vocabs.back());
+      else
+          shortlistGenerator_ = New<data::LexicalShortlistGenerator>(
+              options_, srcVocab, trgVocab_, 0, 1, vocabs.front() == vocabs.back());
+    }
 
     auto devices = Config::getDevices(options_);
     numDevices_ = devices.size();
@@ -87,7 +95,6 @@ public:
         auto prec = options_->get<std::vector<std::string>>("precision", {"float32"});
         graph->setDefaultElementType(typeFromString(prec[0]));
         graph->setDevice(device);
-        graph->getBackend()->configureDevice(options_);
         graph->reserveWorkspaceMB(options_->get<size_t>("workspace"));
         graphs_[id] = graph;
 
@@ -211,9 +218,17 @@ public:
     trgVocab_->load(vocabPaths.back());
 
     // load lexical shortlist
-    if(options_->hasAndNotEmpty("shortlist"))
-      shortlistGenerator_ = New<data::LexicalShortlistGenerator>(
-          options_, srcVocabs_.front(), trgVocab_, 0, 1, vocabPaths.front() == vocabPaths.back());
+    if(options_->hasAndNotEmpty("shortlist")) {
+      auto slOptions = options_->get<std::vector<std::string>>("shortlist");
+      ABORT_IF(slOptions.empty(), "No path to shortlist file given");
+      std::string filename = slOptions[0];
+      if(data::isBinaryShortlist(filename))
+        shortlistGenerator_ = New<data::BinaryShortlistGenerator>(
+            options_, srcVocabs_.front(), trgVocab_, 0, 1, vocabPaths.front() == vocabPaths.back());
+      else
+        shortlistGenerator_ = New<data::LexicalShortlistGenerator>(
+            options_, srcVocabs_.front(), trgVocab_, 0, 1, vocabPaths.front() == vocabPaths.back());
+    }
 
     // get device IDs
     auto devices = Config::getDevices(options_);
@@ -226,7 +241,6 @@ public:
       auto precison = options_->get<std::vector<std::string>>("precision", {"float32"});
       graph->setDefaultElementType(typeFromString(precison[0])); // only use first type, used for parameter type in graph
       graph->setDevice(device);
-      graph->getBackend()->configureDevice(options_);
       graph->reserveWorkspaceMB(options_->get<size_t>("workspace"));
       graphs_.push_back(graph);
 

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -241,8 +241,8 @@ public:
 
       auto precison = options_->get<std::vector<std::string>>("precision", {"float32"});
       graph->setDefaultElementType(typeFromString(precison[0])); // only use first type, used for parameter type in graph
-      graph->getBackend()->configureDevice(options_);
       graph->setDevice(device);
+      graph->getBackend()->configureDevice(options_);
       graph->reserveWorkspaceMB(options_->get<size_t>("workspace"));
       graphs_.push_back(graph);
 

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -95,6 +95,7 @@ public:
         auto prec = options_->get<std::vector<std::string>>("precision", {"float32"});
         graph->setDefaultElementType(typeFromString(prec[0]));
         graph->setDevice(device);
+        graph->getBackend()->configureDevice(options_);
         graph->reserveWorkspaceMB(options_->get<size_t>("workspace"));
         graphs_[id] = graph;
 
@@ -240,6 +241,7 @@ public:
 
       auto precison = options_->get<std::vector<std::string>>("precision", {"float32"});
       graph->setDefaultElementType(typeFromString(precison[0])); // only use first type, used for parameter type in graph
+      graph->getBackend()->configureDevice(options_);
       graph->setDevice(device);
       graph->reserveWorkspaceMB(options_->get<size_t>("workspace"));
       graphs_.push_back(graph);


### PR DESCRIPTION
### Description

This PR adds a new binary shortlist generator which allows the decoder to load a lexical shortlist from a binary blob. 
It is related to issues: #19 

List of changes:
- Add `BinaryShortlistGenerator` Class to load lexical shortlist from a binary blob.
  To use a binary shortlist, you should provide the file path and whether the file needs checking (optional; true by default). 
  For example:
```
--shortlist lex.esen.bin false
``` 
- Add a shortlist converter which can convert a text lexical shortlist to a binary shortlist. This converter is integrated into `marian-conv` with `--shortlist,-s` option
Shortlist conversion usage example:
```
./marian-conv --shortlist lex.esen.s2t 100 100 0 \
               --dump lex.esen.bin \
               --vocabs vocab.esen.spm vocab.esen.spm
```
- Update Marian decoder with an option of loading binary shortlist
- Update `hash.h` for checksum calculation 

Added dependencies: none

### How to test
Manually tested new BinaryShortlistGenerator with legacy LexicalShortlistGenerator. The results are the same. Also passed unit tests. 

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
