### PR TITLE
Enable compiling wasm compatible marian sources natively

### DIFF
--- a/.github/workflows/native-customized_marian-macos.yml
+++ b/.github/workflows/native-customized_marian-macos.yml
@@ -1,0 +1,44 @@
+name: Native (wasm-customized marian)
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build-macos:
+    name: MacOS CPU-only
+    runs-on: macos-10.15
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Configure CMake
+      run: |
+        mkdir -p build
+        cd build
+        cmake cmake \
+          -DCOMPILE_CUDA=off \
+          -DUSE_DOXYGEN=off \
+          -DCOMPILE_EXAMPLES=off \
+          -DCOMPILE_SERVER=off \
+          -DCOMPILE_TESTS=off \
+          -DUSE_FBGEMM=off \
+          -DUSE_SENTENCEPIECE=on \
+          -DUSE_STATIC_LIBS=on \
+          -DUSE_MKL=off \
+          -DUSE_WASM_COMPATIBLE_MARIAN=on ../
+
+    - name: Compile
+      working-directory: build
+      run: make -j2
+
+    - name: Print versions
+      working-directory: build
+      run: |
+        ./marian-decoder --version
+

--- a/.github/workflows/wasm-customized_marian-macos.yml
+++ b/.github/workflows/wasm-customized_marian-macos.yml
@@ -1,4 +1,4 @@
-name: MacOS WASM
+name: WASM (wasm-customized marian)
 
 on:
   push:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-wasm:
-    name: WASM
+    name: WASM CPU-only
     runs-on: macos-10.15
 
     steps:
@@ -37,6 +37,7 @@ jobs:
           -DUSE_SENTENCEPIECE=on \
           -DUSE_STATIC_LIBS=on \
           -DUSE_MKL=off \
+          -DUSE_WASM_COMPATIBLE_MARIAN=on \
           -DCOMPILE_WASM=on ../
 
     - name: Compile

--- a/.github/workflows/wasm-customized_marian-ubuntu.yml
+++ b/.github/workflows/wasm-customized_marian-ubuntu.yml
@@ -1,4 +1,4 @@
-name: WASM (wasm-customized marian) MacOS
+name: WASM (wasm-customized marian) Ubuntu
 
 on:
   push:
@@ -9,7 +9,7 @@ on:
 jobs:
   build-wasm:
     name: WASM CPU-only
-    runs-on: macos-10.15
+    runs-on: ubuntu-latest
 
     steps:
     - name: Setup Emscripten toolchain

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Integrate a shortlist converter (which can convert a text lexical shortlist to a binary shortlist) into marian-conv with --shortlist option
 - Added ONNXJS submodule to use its wasm-compatible sgemm routine for wasm builds
 - Enable compiling marian on wasm platform
+- Added capability to compile wasm compatible marian sources (i.e. the sources that compile on wasm successfully) natively.
 
 ### Fixed
 - Segfault of spm_train when compiled with -DUSE_STATIC_LIBS=ON seems to have gone away with update to newer SentencePiece version.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,15 +28,20 @@ option(USE_SENTENCEPIECE "Download and compile SentencePiece" ON)
 option(USE_STATIC_LIBS "Link statically against non-system libs" OFF)
 option(GENERATE_MARIAN_INSTALL_TARGETS "Generate Marian install targets (requires CMake 3.12+)" OFF)
 option(M32_BINARIES "Generate 32bit binaries even when building outside of WASM. Useful for testing some WASM specific functionality without the need for the compiling to WASM." OFF)
-option(COMPILE_WASM "Compile customized marian for WASM target" OFF)
+option(COMPILE_WASM "Compile (wasm compatible) marian for WASM target" OFF)
+option(USE_WASM_COMPATIBLE_MARIAN "Enable those marian sources that compile to wasm. Useful for debugging wasm failures by building same sources natively" OFF)
 
-# cmake options that are dependent on COMPILE_WASM cmake option
+# cmake options that are dependent on USE_WASM_COMPATIBLE_MARIAN cmake option
 CMAKE_DEPENDENT_OPTION(USE_THREADS "Compile with multi-threading support" OFF
-                       "COMPILE_WASM" ON)
+                       "USE_WASM_COMPATIBLE_MARIAN" ON)
 CMAKE_DEPENDENT_OPTION(USE_WASM_COMPATIBLE_BLAS "Compile with wasm compatible blas" ON
-                       "COMPILE_WASM" OFF)
+                       "USE_WASM_COMPATIBLE_MARIAN" OFF)
 CMAKE_DEPENDENT_OPTION(COMPILE_WITHOUT_EXCEPTIONS "Compile without exceptions" ON
-                       "COMPILE_WASM" OFF)
+                       "USE_WASM_COMPATIBLE_MARIAN" OFF)
+
+if (USE_WASM_COMPATIBLE_MARIAN)
+  add_compile_definitions(WASM)
+endif()
 
 if (COMPILE_WASM)
   set(WORMHOLE ON CACHE BOOL "Use WASM wormhole in intgemm https://bugzilla.mozilla.org/show_bug.cgi?id=1672160")
@@ -240,8 +245,7 @@ else(MSVC)
   if(COMPILE_WASM)
     # Setting USE_SSE2 definition to enable SSE2 specific code in "3rd_party/sse_mathfun.h" for wasm builds
     add_compile_definitions(USE_SSE2)
-    # Add compile definition for wasm builds
-    add_compile_definitions(WASM)
+
     set(PTHREAD_FLAG "-pthread")
     set(DISABLE_PTHREAD_MEMGROWTH_WARNING -Wno-error=pthreads-mem-growth)
     set(CMAKE_CXX_FLAGS                 "-std=c++11 ${PTHREAD_FLAG} ${CMAKE_GCC_FLAGS} -fPIC ${DISABLE_GLOBALLY} ${INTRINSICS}")

--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -2,7 +2,7 @@
 include_directories(.)
 
 add_subdirectory(./yaml-cpp)
-if(NOT COMPILE_WASM)
+if(NOT USE_WASM_COMPATIBLE_MARIAN)
   add_subdirectory(./SQLiteCpp)
   add_subdirectory(./zlib)
   add_subdirectory(./faiss)
@@ -128,7 +128,7 @@ include_directories(./CLI)
 include_directories(./pathie-cpp/include)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  if(NOT COMPILE_WASM)
+  if(NOT USE_WASM_COMPATIBLE_MARIAN)
   #set_target_properties(SQLiteCpp PROPERTIES COMPILE_FLAGS
   set_property(TARGET SQLiteCpp APPEND_STRING PROPERTY COMPILE_FLAGS
     " -Wno-parentheses-equality -Wno-unused-value")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,7 +98,7 @@ set(MARIAN_SOURCES
   $<TARGET_OBJECTS:pathie-cpp>
 )
 
-if (NOT COMPILE_WASM)
+if (NOT USE_WASM_COMPATIBLE_MARIAN)
   list(APPEND MARIAN_SOURCES
     3rd_party/ExceptionWithCallStack.cpp
 
@@ -215,7 +215,7 @@ if (NOT COMPILE_LIBRARY_ONLY)
                           SUFFIX     ".html")
   endif(COMPILE_WASM)
 
-  if (NOT COMPILE_WASM)
+  if (NOT USE_WASM_COMPATIBLE_MARIAN)
   add_executable(marian_train command/marian_main.cpp)
   set_target_properties(marian_train PROPERTIES OUTPUT_NAME marian)
   target_compile_options(marian_train PRIVATE ${ALL_WARNINGS})
@@ -276,7 +276,7 @@ if (NOT COMPILE_LIBRARY_ONLY)
     endif(MSVC)
     set(EXECUTABLES ${EXECUTABLES} marian_server)
   endif(COMPILE_SERVER)
-  endif(NOT COMPILE_WASM)
+  endif(NOT USE_WASM_COMPATIBLE_MARIAN)
 
   foreach(exec ${EXECUTABLES})
     target_link_libraries(${exec} marian)

--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -17,6 +17,7 @@ cmake_native_decoder_cmd += -DUSE_FBGEMM=off
 cmake_native_decoder_cmd += -DCOMPILE_LIBRARY_ONLY=off
 cmake_native_decoder_cmd += -DUSE_MKL=off
 cmake_native_decoder_cmd += -DCOMPILE_CPU=on
+cmake_native_decoder_cmd += -DUSE_WASM_COMPATIBLE_MARIAN=on
 
 # Commands for wasm compilation:
 cmake_wasm_decoder_cmd = ${cmake_native_decoder_cmd}

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -20,7 +20,7 @@ For docker based builds, please refer [Docker Compilation Steps](#Docker-Compila
         ```bash
         mkdir build-wasm; cd build-wasm
 
-        emcmake cmake -DCOMPILE_CUDA=off -DUSE_STATIC_LIBS=on -DUSE_DOXYGEN=off -DUSE_FBGEMM=off -DUSE_MKL=off -DUSE_NCCL=off -DCOMPILE_WASM=on ../
+        emcmake cmake -DCOMPILE_CUDA=off -DUSE_STATIC_LIBS=on -DUSE_DOXYGEN=off -DUSE_FBGEMM=off -DUSE_MKL=off -DUSE_NCCL=off -DUSE_WASM_COMPATIBLE_MARIAN=on -DCOMPILE_WASM=on ../
 
         emmake make -j
         ```


### PR DESCRIPTION
### Description
Compiling to wasm platform for inference requires only a subset of marian sources. This PR introduces the ability to compile these sources to native platform as well.

Motivation of this change?
Doing this enables debugging the wasm runtime failures by first reproducing the same failures on native platform with the native binaries built using the same sources that were used to build wasm binary. In the past, this has proven to be useful where we could quickly diagnose a few wasm specific issues (e.g. `size_t` inconsistency).

List of changes:
- Encapsulate all wasm compatible sources under a single cmake option
- Added a github workflow to compile these wasm compatible sources natively as well

Added dependencies: none

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
