### PR TITLE
Cmake option and preprocessor cleanup for wasm platform

### DIFF
--- a/.github/workflows/native-customized_marian-macos.yml
+++ b/.github/workflows/native-customized_marian-macos.yml
@@ -31,7 +31,7 @@ jobs:
           -DUSE_SENTENCEPIECE=on \
           -DUSE_STATIC_LIBS=on \
           -DUSE_MKL=off \
-          -DUSE_WASM_COMPATIBLE_MARIAN=on ../
+          -DUSE_WASM_COMPATIBLE_SOURCE=on ../
 
     - name: Compile
       working-directory: build

--- a/.github/workflows/wasm-customized_marian-macos.yml
+++ b/.github/workflows/wasm-customized_marian-macos.yml
@@ -37,7 +37,7 @@ jobs:
           -DUSE_SENTENCEPIECE=on \
           -DUSE_STATIC_LIBS=on \
           -DUSE_MKL=off \
-          -DUSE_WASM_COMPATIBLE_MARIAN=on \
+          -DUSE_WASM_COMPATIBLE_SOURCE=on \
           -DCOMPILE_WASM=on ../
 
     - name: Compile

--- a/.github/workflows/wasm-customized_marian-ubuntu.yml
+++ b/.github/workflows/wasm-customized_marian-ubuntu.yml
@@ -37,7 +37,7 @@ jobs:
           -DUSE_SENTENCEPIECE=on \
           -DUSE_STATIC_LIBS=on \
           -DUSE_MKL=off \
-          -DUSE_WASM_COMPATIBLE_MARIAN=on \
+          -DUSE_WASM_COMPATIBLE_SOURCE=on \
           -DCOMPILE_WASM=on ../
 
     - name: Compile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,21 +29,24 @@ option(USE_STATIC_LIBS "Link statically against non-system libs" OFF)
 option(GENERATE_MARIAN_INSTALL_TARGETS "Generate Marian install targets (requires CMake 3.12+)" OFF)
 option(M32_BINARIES "Generate 32bit binaries even when building outside of WASM. Useful for testing some WASM specific functionality without the need for the compiling to WASM." OFF)
 option(COMPILE_WASM "Compile (wasm compatible) marian for WASM target" OFF)
-option(USE_WASM_COMPATIBLE_MARIAN "Enable those marian sources that compile to wasm. Useful for debugging wasm failures by building same sources natively" OFF)
+option(USE_WASM_COMPATIBLE_SOURCE "Enable the minimal marian sources that compile to wasm. Useful for debugging wasm failures by building same sources natively" OFF)
 
-# cmake options that are dependent on USE_WASM_COMPATIBLE_MARIAN cmake option
+# cmake options that are dependent on USE_WASM_COMPATIBLE_SOURCE cmake option
 CMAKE_DEPENDENT_OPTION(USE_THREADS "Compile with multi-threading support" OFF
-                       "USE_WASM_COMPATIBLE_MARIAN" ON)
+                       "USE_WASM_COMPATIBLE_SOURCE" ON)
 CMAKE_DEPENDENT_OPTION(USE_WASM_COMPATIBLE_BLAS "Compile with wasm compatible blas" ON
-                       "USE_WASM_COMPATIBLE_MARIAN" OFF)
+                       "USE_WASM_COMPATIBLE_SOURCE" OFF)
 CMAKE_DEPENDENT_OPTION(COMPILE_WITHOUT_EXCEPTIONS "Compile without exceptions" ON
-                       "USE_WASM_COMPATIBLE_MARIAN" OFF)
+                       "USE_WASM_COMPATIBLE_SOURCE" OFF)
 
-if (USE_WASM_COMPATIBLE_MARIAN)
-  add_compile_definitions(WASM)
+if (USE_WASM_COMPATIBLE_SOURCE)
+  add_compile_definitions(WASM_COMPATIBLE_SOURCE)
+  # Setting USE_SSE2 definition to enable SSE2 specific code in "3rd_party/sse_mathfun.h" for wasm builds
+  add_compile_definitions(USE_SSE2)
 endif()
 
 if (COMPILE_WASM)
+  add_compile_definitions(WASM)
   set(WORMHOLE ON CACHE BOOL "Use WASM wormhole in intgemm https://bugzilla.mozilla.org/show_bug.cgi?id=1672160")
 endif()
 
@@ -243,9 +246,6 @@ else(MSVC)
   endif(CMAKE_COMPILER_IS_GNUCC)
 
   if(COMPILE_WASM)
-    # Setting USE_SSE2 definition to enable SSE2 specific code in "3rd_party/sse_mathfun.h" for wasm builds
-    add_compile_definitions(USE_SSE2)
-
     set(PTHREAD_FLAG "-pthread")
     set(DISABLE_PTHREAD_MEMGROWTH_WARNING -Wno-error=pthreads-mem-growth)
     set(CMAKE_CXX_FLAGS                 "-std=c++11 ${PTHREAD_FLAG} ${CMAKE_GCC_FLAGS} -fPIC ${DISABLE_GLOBALLY} ${INTRINSICS}")

--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -2,7 +2,7 @@
 include_directories(.)
 
 add_subdirectory(./yaml-cpp)
-if(NOT USE_WASM_COMPATIBLE_MARIAN)
+if(NOT USE_WASM_COMPATIBLE_SOURCE)
   add_subdirectory(./SQLiteCpp)
   add_subdirectory(./zlib)
   add_subdirectory(./faiss)
@@ -128,7 +128,7 @@ include_directories(./CLI)
 include_directories(./pathie-cpp/include)
 
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  if(NOT USE_WASM_COMPATIBLE_MARIAN)
+  if(NOT USE_WASM_COMPATIBLE_SOURCE)
   #set_target_properties(SQLiteCpp PROPERTIES COMPILE_FLAGS
   set_property(TARGET SQLiteCpp APPEND_STRING PROPERTY COMPILE_FLAGS
     " -Wno-parentheses-equality -Wno-unused-value")

--- a/src/3rd_party/cnpy/cnpy.h
+++ b/src/3rd_party/cnpy/cnpy.h
@@ -5,7 +5,7 @@
 #ifndef LIBCNPY_H_
 #define LIBCNPY_H_
 
-#if !defined(WASM)
+#if !defined(WASM_COMPATIBLE_SOURCE)
 #include "3rd_party/zlib/zlib.h"
 #endif
 
@@ -135,7 +135,7 @@ namespace cnpy {
 
     template<typename T> void npz_save(std::string zipname, std::string fname, const T* data, const unsigned int* shape, const unsigned int ndims, std::string mode = "w")
     {
-#if defined(WASM)
+#if defined(WASM_COMPATIBLE_SOURCE)
         throw std::runtime_error("npz_save() not supported in WASM builds");
 #else
         //first, append a .npy to the fname
@@ -271,7 +271,7 @@ namespace cnpy {
     static inline
     void npz_save(std::string zipname, const std::vector<NpzItem>& items)
     {
-#if defined(WASM)
+#if defined(WASM_COMPATIBLE_SOURCE)
         throw std::runtime_error("npz_save() not supported in WASM builds");
 #else
         auto tmpname = zipname + "$$"; // TODO: add thread id or something

--- a/src/3rd_party/pathie-cpp/src/path.cpp
+++ b/src/3rd_party/pathie-cpp/src/path.cpp
@@ -935,7 +935,7 @@ Path Path::exe()
 
   std::string str = utf16_to_utf8(buf);
   return Path(str);
-#elif defined(WASM)
+#elif defined(WASM_COMPATIBLE_SOURCE)
   throw(std::runtime_error("Path::exe() not supported in WASM builds"));
 #else
 #error Unsupported platform.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,7 +98,7 @@ set(MARIAN_SOURCES
   $<TARGET_OBJECTS:pathie-cpp>
 )
 
-if (NOT USE_WASM_COMPATIBLE_MARIAN)
+if (NOT USE_WASM_COMPATIBLE_SOURCE)
   list(APPEND MARIAN_SOURCES
     3rd_party/ExceptionWithCallStack.cpp
 
@@ -215,7 +215,7 @@ if (NOT COMPILE_LIBRARY_ONLY)
                           SUFFIX     ".html")
   endif(COMPILE_WASM)
 
-  if (NOT USE_WASM_COMPATIBLE_MARIAN)
+  if (NOT USE_WASM_COMPATIBLE_SOURCE)
   add_executable(marian_train command/marian_main.cpp)
   set_target_properties(marian_train PROPERTIES OUTPUT_NAME marian)
   target_compile_options(marian_train PRIVATE ${ALL_WARNINGS})
@@ -276,7 +276,7 @@ if (NOT COMPILE_LIBRARY_ONLY)
     endif(MSVC)
     set(EXECUTABLES ${EXECUTABLES} marian_server)
   endif(COMPILE_SERVER)
-  endif(NOT USE_WASM_COMPATIBLE_MARIAN)
+  endif(NOT USE_WASM_COMPATIBLE_SOURCE)
 
   foreach(exec ${EXECUTABLES})
     target_link_libraries(${exec} marian)

--- a/src/common/file_stream.cpp
+++ b/src/common/file_stream.cpp
@@ -23,7 +23,7 @@ InputFileStream::InputFileStream(const std::string &file)
     : std::istream(NULL) {
   // the special syntax "command |" starts command in a sh shell and reads out its result
   if (marian::utils::endsWith(file, "|")) {
-#if defined(__unix__) && !defined(WASM)
+#if defined(__unix__) && !defined(WASM_COMPATIBLE_SOURCE)
     auto command = file.substr(0, file.size() - 1);
     // open as a pipe
     pipe_ = popen(command.c_str(), "r");
@@ -45,7 +45,7 @@ InputFileStream::InputFileStream(const std::string &file)
 
   // insert .gz decompression
   if(marian::utils::endsWith(file, ".gz")) {
-#if defined(WASM)
+#if defined(WASM_COMPATIBLE_SOURCE)
     ABORT(".gz file decompression not supported in WASM builds of Marian: {}", file);
 #else
     streamBuf2_ = std::move(streamBuf1_);
@@ -98,7 +98,7 @@ OutputFileStream::OutputFileStream(const std::string &file)
   ABORT_IF(ret != streamBuf1_.get(), "Return value is not equal to streambuf pointer, that is weird");
 
   if(file_.extension() == marian::filesystem::Path(".gz")) {
-#if defined(WASM)
+#if defined(WASM_COMPATIBLE_SOURCE)
     ABORT(".gz file decompression not supported in WASM builds of Marian: {}", file);
 #else
     streamBuf2_.reset(new zstr::ostreambuf(streamBuf1_.get()));

--- a/src/common/file_stream.h
+++ b/src/common/file_stream.h
@@ -26,7 +26,7 @@
 #pragma warning(push) // 4101: 'identifier' : unreferenced local variable. One parameter variable in zstr.hpp is not used.
 #pragma warning(disable : 4101)
 #endif
-#ifndef WASM
+#ifndef WASM_COMPATIBLE_SOURCE
 #include "3rd_party/zstr/zstr.hpp"
 #endif
 #ifdef _MSC_VER

--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -145,7 +145,7 @@ void switchtoMultinodeLogging(std::string nodeIdStr) {
 
 namespace marian {
   std::string noinline getCallStack(size_t skipLevels) {
-  #ifdef WASM
+  #ifdef WASM_COMPATIBLE_SOURCE
     return "Callstacks not supported in WASM builds currently";
   #else
     return ::Microsoft::MSR::CNTK::DebugUtil::GetCallStack(skipLevels + 2, /*makeFunctionNamesStandOut=*/true);

--- a/src/functional/operators.h
+++ b/src/functional/operators.h
@@ -265,7 +265,7 @@ struct Ops<float32x4> {
 
   // @TODO: get rid of loop4 with proper intrisics
   static inline float32x4 sgn(const float32x4& x)  { return loop4(Ops<float>::sgn, x); }
-#ifndef WASM
+#ifndef WASM_COMPATIBLE_SOURCE
   static inline float32x4 round(const float32x4& x)  { return _mm_round_ps(x, _MM_FROUND_TO_NEAREST_INT); }
   static inline float32x4 floor(const float32x4& x)  { return _mm_floor_ps(x); }
   static inline float32x4 ceil(const float32x4& x)   { return _mm_ceil_ps(x); }

--- a/src/graph/node_initializers.cpp
+++ b/src/graph/node_initializers.cpp
@@ -254,7 +254,7 @@ template Ptr<NodeInitializer> range<IndexType>(IndexType begin, IndexType end, I
 }  // namespace marian
 
 
-#if BLAS_FOUND && !WASM
+#if BLAS_FOUND && !WASM_COMPATIBLE_SOURCE
 #include "faiss/VectorTransform.h"
 
 namespace marian {

--- a/src/layers/generic.cpp
+++ b/src/layers/generic.cpp
@@ -221,7 +221,7 @@ namespace marian {
 
       // this option is only set in the decoder
       if(!lsh_ && options_->hasAndNotEmpty("output-approx-knn")) {
-#ifdef WASM
+#ifdef WASM_COMPATIBLE_SOURCE
         ABORT("LSH is not supported in wasm builds of marian.");
 #else
         auto k     = opt<std::vector<int>>("output-approx-knn")[0];
@@ -281,7 +281,7 @@ namespace marian {
         if(lsh_) {
           ABORT_IF( transA, "Transposed query not supported for LSH");
           ABORT_IF(!transB, "Untransposed indexed matrix not supported for LSH");
-#ifdef WASM
+#ifdef WASM_COMPATIBLE_SOURCE
           ABORT("LSH is not supported in wasm builds of marian.");
 #else
           return lsh_->apply(x, W, b); // knows how to deal with undefined bias

--- a/src/layers/lsh.h
+++ b/src/layers/lsh.h
@@ -18,7 +18,7 @@ public:
   Expr apply(Expr query, Expr values, Expr bias);
 
 private:
-#ifndef WASM
+#ifndef WASM_COMPATIBLE_SOURCE
   Ptr<faiss::IndexLSH> index_;
 #endif
   size_t indexHash_{0};

--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -17,7 +17,7 @@ cmake_native_decoder_cmd += -DUSE_FBGEMM=off
 cmake_native_decoder_cmd += -DCOMPILE_LIBRARY_ONLY=off
 cmake_native_decoder_cmd += -DUSE_MKL=off
 cmake_native_decoder_cmd += -DCOMPILE_CPU=on
-cmake_native_decoder_cmd += -DUSE_WASM_COMPATIBLE_MARIAN=on
+cmake_native_decoder_cmd += -DUSE_WASM_COMPATIBLE_SOURCE=on
 
 # Commands for wasm compilation:
 cmake_wasm_decoder_cmd = ${cmake_native_decoder_cmd}

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -20,7 +20,7 @@ For docker based builds, please refer [Docker Compilation Steps](#Docker-Compila
         ```bash
         mkdir build-wasm; cd build-wasm
 
-        emcmake cmake -DCOMPILE_CUDA=off -DUSE_STATIC_LIBS=on -DUSE_DOXYGEN=off -DUSE_FBGEMM=off -DUSE_MKL=off -DUSE_NCCL=off -DUSE_WASM_COMPATIBLE_MARIAN=on -DCOMPILE_WASM=on ../
+        emcmake cmake -DCOMPILE_CUDA=off -DUSE_STATIC_LIBS=on -DUSE_DOXYGEN=off -DUSE_FBGEMM=off -DUSE_MKL=off -DUSE_NCCL=off -DUSE_WASM_COMPATIBLE_SOURCE=on -DCOMPILE_WASM=on ../
 
         emmake make -j
         ```


### PR DESCRIPTION
### Description

This PR improves the names of cmake options (and corresponding compile definitions set by them) that are specific to wasm platform.


List of changes:
- Renamed `USE_WASM_COMPATIBLE_MARIAN` cmake option to `USE_WASM_COMPATIBLE_SOURCE` as per [agreement](https://github.com/browsermt/bergamot-translator/pull/74#issuecomment-811091459)
    - This cmake option is used to enable a subset of marian sources that compile to wasm
- Use `WASM_COMPATIBLE_SOURCE` compile definition at all places where `WASM` compile definition was wrongly used

Added dependencies: none

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md

This PR doesn't add/modify/remove any functionality. Therefore, I didn't update the CHANGELOG.md. Please let me know if I still need to update it.