### PR TITLE
Upgrade cmake_minimum_required to 3.12.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.1)
+cmake_minimum_required(VERSION 3.12.4)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 if (POLICY CMP0074)


### PR DESCRIPTION
### Description
Upgrades the minimum required cmake version to 3.12.4

This PR is related to the issue: https://github.com/browsermt/marian-dev/issues/33

Added dependencies: none

### Checklist

- [ ] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
