### PR TITLE
Fixing Mac and Ubuntu CI failures

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -18,7 +18,9 @@ jobs:
         submodules: recursive
 
     - name: Install dependencies
-      run: brew install openblas protobuf
+      run: |
+        brew update
+        brew install openblas protobuf
 
     # Openblas location is exported explicitly because openblas is keg-only,
     # which means it was not symlinked into /usr/local/.

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -72,7 +72,7 @@ jobs:
     # No need to install libprotobuf{17,10,9v5} on Ubuntu {20,18,16}.04 because it is installed together with libprotobuf-dev
     # Boost is no longer pre-installed on GitHub-hosted runners
     - name: Install dependencies
-      run: sudo apt-get install -y libgoogle-perftools-dev libprotobuf-dev protobuf-compiler libboost-system-dev
+      run: sudo apt-get install -y libgoogle-perftools-dev libprotobuf-dev protobuf-compiler libboost-system-dev g++-${{ matrix.gcc }}
 
     # https://software.intel.com/content/www/us/en/develop/articles/installing-intel-free-libs-and-python-apt-repo.html
     - name: Install MKL


### PR DESCRIPTION
### Description
The PR fixes the CI failures happened because of recent changes in Github builders.

Added dependencies: none

### Checklist

- [ ] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md