### PR TITLE
Enable binary vocab loading from buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added ONNXJS submodule to use its wasm-compatible sgemm routine for wasm builds
 - Enable compiling marian on wasm platform
 - Added capability to compile wasm compatible marian sources (i.e. the sources that compile on wasm successfully) natively.
+- Enable loading SentencePiece vocabs from protobuf
 
 ### Fixed
 - Segfault of spm_train when compiled with -DUSE_STATIC_LIBS=ON seems to have gone away with update to newer SentencePiece version.

--- a/src/data/default_vocab.cpp
+++ b/src/data/default_vocab.cpp
@@ -135,6 +135,10 @@ public:
     return std::max(id2str_.size(), maxSize);
   }
 
+  virtual size_t loadFromSerialized(absl::string_view serialized) override {
+    ABORT("[data] Load Serialized DefaultVocabulary not supported");
+  }
+
   // for fakeBatch()
   virtual void createFake() override {
     eosId_ = insertWord(Word::DEFAULT_EOS_ID, DEFAULT_EOS_STR);

--- a/src/data/default_vocab.cpp
+++ b/src/data/default_vocab.cpp
@@ -135,9 +135,6 @@ public:
     return std::max(id2str_.size(), maxSize);
   }
 
-  virtual size_t loadFromSerialized(absl::string_view serialized) override {
-    ABORT("[data] Load Serialized DefaultVocabulary not supported");
-  }
 
   // for fakeBatch()
   virtual void createFake() override {

--- a/src/data/default_vocab.cpp
+++ b/src/data/default_vocab.cpp
@@ -134,8 +134,7 @@ public:
 
     return std::max(id2str_.size(), maxSize);
   }
-
-
+  
   // for fakeBatch()
   virtual void createFake() override {
     eosId_ = insertWord(Word::DEFAULT_EOS_ID, DEFAULT_EOS_STR);

--- a/src/data/factored_vocab.h
+++ b/src/data/factored_vocab.h
@@ -24,7 +24,6 @@ public:
 
   // from IVocab:
   virtual size_t load(const std::string& factoredVocabPath, size_t maxSizeUnused = 0) override final;
-  virtual size_t loadFromSerialized(absl::string_view serialized) override final { ABORT("[data] Load Serialized FactoredVocab vocabulary not supported"); }
   virtual void create(const std::string& vocabPath, const std::vector<std::string>& trainPaths, size_t maxSize) override final { vocabPath, trainPaths, maxSize; ABORT("Factored vocab cannot be created on the fly"); }
   virtual const std::string& canonicalExtension() const override final { return suffixes()[0]; }
   virtual const std::vector<std::string>& suffixes() const override final;

--- a/src/data/factored_vocab.h
+++ b/src/data/factored_vocab.h
@@ -24,6 +24,7 @@ public:
 
   // from IVocab:
   virtual size_t load(const std::string& factoredVocabPath, size_t maxSizeUnused = 0) override final;
+  virtual size_t loadFromSerialized(absl::string_view serialized) override final { ABORT("[data] Load Serialized FactoredVocab vocabulary not supported"); }
   virtual void create(const std::string& vocabPath, const std::vector<std::string>& trainPaths, size_t maxSize) override final { vocabPath, trainPaths, maxSize; ABORT("Factored vocab cannot be created on the fly"); }
   virtual const std::string& canonicalExtension() const override final { return suffixes()[0]; }
   virtual const std::vector<std::string>& suffixes() const override final;

--- a/src/data/sentencepiece_vocab.cpp
+++ b/src/data/sentencepiece_vocab.cpp
@@ -306,7 +306,7 @@ public:
     return spm_->GetPieceSize();
   }
 
-  size_t loadFromSerialized(absl::string_view serialized) override {
+  size_t loadFromSerialized(const string_view& serialized) override {
     LOG(info, "[data] Loading SentencePiece vocabulary from buffer");
 
     spm_.reset(new sentencepiece::SentencePieceProcessor());

--- a/src/data/sentencepiece_vocab.cpp
+++ b/src/data/sentencepiece_vocab.cpp
@@ -306,6 +306,20 @@ public:
     return spm_->GetPieceSize();
   }
 
+  size_t loadFromSerialized(absl::string_view serialized) override {
+    LOG(info, "[data] Loading SentencePiece vocabulary from buffer");
+
+    spm_.reset(new sentencepiece::SentencePieceProcessor());
+    const auto status = spm_->LoadFromSerializedProto(serialized);
+
+    ABORT_IF(!status.ok(),
+             "SentencePiece vocabulary error: {}",
+             status.ToString());
+
+    return spm_->GetPieceSize();
+
+  }
+
   std::string toUpper(const std::string& line) const override { return utils::utf8ToUpper(line); }
   std::string toEnglishTitleCase(const std::string& line) const override { return utils::toEnglishTitleCase(line); }
 };

--- a/src/data/sentencepiece_vocab.cpp
+++ b/src/data/sentencepiece_vocab.cpp
@@ -306,6 +306,9 @@ public:
     return spm_->GetPieceSize();
   }
 
+  // loadFromSerialized() is based on `absl::string_view` which does *not* own the
+  // memory to which it points. So be sure that the underlying memory is alive during
+  // loading (and no copy will be generated)
   size_t loadFromSerialized(const string_view& serialized) override {
     LOG(info, "[data] Loading SentencePiece vocabulary from buffer");
 

--- a/src/data/vocab.cpp
+++ b/src/data/vocab.cpp
@@ -72,6 +72,12 @@ size_t Vocab::load(const std::string& vocabPath, size_t maxSize) {
   return vImpl_->load(vocabPath, (int)maxSize);
 }
 
+size_t Vocab::loadFromSerialized(absl::string_view serialized) {
+  if (!vImpl_)
+    vImpl_ = createSentencePieceVocab("vocab.spm", options_, batchIndex_); // currently only support SentencePieceVocab
+  return vImpl_->loadFromSerialized(serialized);
+}
+
 void Vocab::create(const std::string& vocabPath,
                    const std::vector<std::string>& trainPaths,
                    size_t maxSize) {

--- a/src/data/vocab.cpp
+++ b/src/data/vocab.cpp
@@ -72,7 +72,7 @@ size_t Vocab::load(const std::string& vocabPath, size_t maxSize) {
   return vImpl_->load(vocabPath, (int)maxSize);
 }
 
-size_t Vocab::loadFromSerialized(absl::string_view serialized) {
+size_t Vocab::loadFromSerialized(const string_view& serialized) {
   if (!vImpl_)
     vImpl_ = createSentencePieceVocab("vocab.spm", options_, batchIndex_); // currently only support SentencePieceVocab
   return vImpl_->loadFromSerialized(serialized);

--- a/src/data/vocab.h
+++ b/src/data/vocab.h
@@ -31,7 +31,7 @@ public:
 
   size_t load(const std::string& vocabPath, size_t maxSize = 0);
 
-  size_t loadFromSerialized(absl::string_view serialized);
+  size_t loadFromSerialized(const string_view& serialized);
 
   void create(const std::string& vocabPath,
               const std::vector<std::string>& trainPaths,

--- a/src/data/vocab.h
+++ b/src/data/vocab.h
@@ -31,6 +31,8 @@ public:
 
   size_t load(const std::string& vocabPath, size_t maxSize = 0);
 
+  size_t loadFromSerialized(absl::string_view serialized);
+
   void create(const std::string& vocabPath,
               const std::vector<std::string>& trainPaths,
               size_t maxSize);

--- a/src/data/vocab_base.h
+++ b/src/data/vocab_base.h
@@ -10,6 +10,7 @@ namespace marian {
 class IVocab {
 public:
   virtual size_t load(const std::string& vocabPath, size_t maxSize = 0) = 0;
+  virtual size_t loadFromSerialized(absl::string_view serialized) = 0;
 
   virtual void create(const std::string& vocabPath,
                       const std::vector<std::string>& trainPaths,

--- a/src/data/vocab_base.h
+++ b/src/data/vocab_base.h
@@ -10,7 +10,9 @@ namespace marian {
 class IVocab {
 public:
   virtual size_t load(const std::string& vocabPath, size_t maxSize = 0) = 0;
-  virtual size_t loadFromSerialized(absl::string_view serialized) = 0;
+  virtual size_t loadFromSerialized(const string_view& serialized){
+    ABORT("loadFromSerialized(...) is not implemented for this VocabType.");
+  }
 
   virtual void create(const std::string& vocabPath,
                       const std::vector<std::string>& trainPaths,


### PR DESCRIPTION
### Description

This PR enables loading SentencePiece vocabs from the buffer which is required in bergamot-translator.
It is related to https://github.com/browsermt/bergamot-translator/pull/122

List of changes:
- Add `loadFromSerialized()` in `data/vocab.h`, `data/vocab_base.h `, `data/vocab.cpp` and `data/default_vocab.cpp`.
- Implement `loadFromSerialized()` in `data/sentencepiece_vocab.cpp`

Added dependencies: none

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
