### PR TITLE
Scorer model loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Disable the undocumented `mmap()` codepath. It is now used for loading models from binary byte arrays.
+- Preload model to Item vector before creating scorers
 
 ### Added
 - Add --train-embedder-rank for fine-tuning any encoder(-decoder) model for multi-lingual similarity via softmax-margin loss

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -184,9 +184,12 @@ void ConfigParser::addOptionsModel(cli::CLIWrapper& cli) {
         "Path prefix for pre-trained model to initialize model weights");
     }
   }
-
-  cli.add<bool>("--model-mmap",
+#ifdef COMPILE_CPU
+  if(mode_ == cli::mode::translation) {
+    cli.add<bool>("--model-mmap",
       "Use memory-mapping when loading model (CPU only)");
+  }
+#endif
   cli.add<bool>("--ignore-model-config",
       "Ignore the model configuration saved in npz file");
   cli.add<std::string>("--type",

--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -185,6 +185,8 @@ void ConfigParser::addOptionsModel(cli::CLIWrapper& cli) {
     }
   }
 
+  cli.add<bool>("--model-mmap",
+      "Use memory-mapping when loading model (CPU only)");
   cli.add<bool>("--ignore-model-config",
       "Ignore the model configuration saved in npz file");
   cli.add<std::string>("--type",

--- a/src/common/config_validator.cpp
+++ b/src/common/config_validator.cpp
@@ -52,6 +52,9 @@ void ConfigValidator::validateOptionsTranslation() const {
   ABORT_IF(models.empty() && configs.empty(),
            "You need to provide at least one model file or a config file");
 
+  ABORT_IF(get<bool>("model-mmap") && get<size_t>("cpu-threads") == 0,
+           "Model MMAP is CPU-only, please use --cpu-threads");
+
   for(const auto& modelFile : models) {
     filesystem::Path modelPath(modelFile);
     ABORT_IF(!filesystem::exists(modelPath), "Model file does not exist: " + modelFile);

--- a/src/common/io.cpp
+++ b/src/common/io.cpp
@@ -56,6 +56,18 @@ void getYamlFromModel(YAML::Node& yaml,
     yaml = YAML::Load(item.data());
 }
 
+// Load YAML from item
+void getYamlFromModel(YAML::Node& yaml,
+                      const std::string& varName,
+                      const std::vector<Item>& items) {
+    for(auto& item : items) {
+      if(item.name == varName) {
+        yaml = YAML::Load(item.data());
+        return;
+      }
+    }
+}
+
 void addMetaToItems(const std::string& meta,
                     const std::string& varName,
                     std::vector<io::Item>& items) {

--- a/src/common/io.h
+++ b/src/common/io.h
@@ -21,6 +21,7 @@ bool isBin(const std::string& fileName);
 
 void getYamlFromModel(YAML::Node& yaml, const std::string& varName, const std::string& fileName);
 void getYamlFromModel(YAML::Node& yaml, const std::string& varName, const void* ptr);
+void getYamlFromModel(YAML::Node& yaml, const std::string& varName, const std::vector<Item>& items);
 
 void addMetaToItems(const std::string& meta,
                     const std::string& varName,

--- a/src/graph/expression_graph.h
+++ b/src/graph/expression_graph.h
@@ -71,7 +71,7 @@ public:
 
   Ptr<Allocator>       getAllocator() { return tensors_->allocator(); }
   Ptr<TensorAllocator> getTensorAllocator() { return tensors_; }
-  
+
   Expr findOrRemember(Expr node) {
     size_t hash = node->hash();
     // memoize constant nodes that are not parameters
@@ -188,7 +188,7 @@ protected:
   ExpressionGraph(ExpressionGraph&&) = delete;
 
   // Holds memory and expressions that correspond to graph parameters
-  // Now we can have multiple types of parameters in a separate parameters object per value type. 
+  // Now we can have multiple types of parameters in a separate parameters object per value type.
   // This is currently only accessible through private functions during loading, will abort during training
   // when params() is called (e.g. optimizer) and there is more or other types than the default parameter type.
   // Currently the only usecase is inference. Trying to access params() for non-default parameter type is going
@@ -307,9 +307,9 @@ private:
 
   // Find the named parameter and its typed parent parameter object (params) and return both.
   // If the parameter is not found return the parent parameter object that the parameter should be added to.
-  // Return [nullptr, nullptr] if no matching parent parameter object exists. 
-  std::tuple<Expr, Ptr<Parameters>> findParams(const std::string& name, 
-                                               Type elementType, 
+  // Return [nullptr, nullptr] if no matching parent parameter object exists.
+  std::tuple<Expr, Ptr<Parameters>> findParams(const std::string& name,
+                                               Type elementType,
                                                bool typeSpecified) const {
     Expr p; Ptr<Parameters> params;
     if(typeSpecified) { // type has been specified, so we are only allowed to look for a parameter with that type
@@ -321,12 +321,12 @@ private:
     } else { // type has not been specified, so we take any type as long as the name matches
       for(auto kvParams : paramsByElementType_) {
         p = kvParams.second->get(name);
-        
+
         if(p) { // p has been found, return with matching params object
           params = kvParams.second;
           break;
         }
-        
+
         if(kvParams.first == elementType) // even if p has not been found, set the params object to be returned
           params = kvParams.second;
       }
@@ -347,8 +347,8 @@ private:
 
     Expr p; Ptr<Parameters> params; std::tie
     (p, params) = findParams(name, elementType, typeSpecified);
-    
-    if(!params) { 
+
+    if(!params) {
       params = New<Parameters>(elementType);
       params->init(backend_);
       paramsByElementType_.insert({elementType, params});
@@ -471,13 +471,13 @@ public:
     return p;
   }
 
-  Ptr<Parameters>& params() { 
+  Ptr<Parameters>& params() {
     // There are no parameter objects, that's weird.
     ABORT_IF(paramsByElementType_.empty(), "No parameter object has been created");
-    
+
     // Safeguard against accessing parameters from the outside with multiple parameter types, not yet supported
     //ABORT_IF(paramsByElementType_.size() > 1, "Calling of params() is currently not supported with multiple ({}) parameters", paramsByElementType_.size());
-    
+
     // Safeguard against accessing parameters from the outside with other than default parameter type, not yet supported
     auto it = paramsByElementType_.find(defaultElementType_);
     ABORT_IF(it == paramsByElementType_.end(), "Parameter object for type {} does not exist", defaultElementType_);
@@ -486,8 +486,8 @@ public:
   }
 
   void setDefaultElementType(Type defaultElementType) {
-    ABORT_IF(!paramsByElementType_.empty() && defaultElementType != defaultElementType_, 
-             "Parameter objects already exist, cannot change default type from {} to {}", 
+    ABORT_IF(!paramsByElementType_.empty() && defaultElementType != defaultElementType_,
+             "Parameter objects already exist, cannot change default type from {} to {}",
              defaultElementType_, defaultElementType);
     defaultElementType_ = defaultElementType;
   }
@@ -533,14 +533,14 @@ public:
 
 public:
   // loading from array of io::Items
-  void load(std::vector<io::Item>& ioItems, bool markReloaded = true) {
+  void load(const std::vector<io::Item>& ioItems, bool markReloaded = true) {
     setReloaded(false);
     for(auto& item : ioItems) {
       std::string pName = item.name;
       // skip over special parameters starting with "special:"
       if(pName.substr(0, 8) == "special:")
         continue;
-      
+
       // if during loading the loaded type is of the same type class as the default element type, allow conversion;
       // otherwise keep the loaded type. This is used when e.g. loading a float32 model as a float16 model as both
       // have type class TypeClass::float_type.
@@ -569,9 +569,9 @@ public:
 
     LOG(info, "Memory mapping model at {}", ptr);
     auto items = io::mmapItems(ptr);
-    
+
     // Deal with default parameter set object that might not be a mapped object.
-    // This gets assigned during ExpressionGraph::setDevice(...) and by default 
+    // This gets assigned during ExpressionGraph::setDevice(...) and by default
     // would contain allocated tensors. Here we replace it with a mmapped version.
     /* This codepath makes MMAP loading work. However, We  are hijacking this codepath to load binary models
      * Without mmap'ing them. AS a result we break the hidden mmap support.

--- a/src/models/amun.h
+++ b/src/models/amun.h
@@ -89,8 +89,6 @@ public:
     if(opt<bool>("tied-embeddings-src") || opt<bool>("tied-embeddings-all"))
       nameMap["Wemb"] = "Wemb";
 
-    LOG(info, "[amun] Loading model from item");
-    // load items from .npz file
     auto ioItems = items;
     // map names and remove a dummy matrices
     for(auto it = ioItems.begin(); it != ioItems.end();) {
@@ -114,8 +112,6 @@ public:
   void load(Ptr<ExpressionGraph> graph,
             const std::string& name,
             bool /*markReloaded*/ = true) override {
-    LOG(info, "[amun] Loading model from file {}", name);
-    // load items from .npz file
     auto ioItems = io::loadItems(name);
     load(graph, ioItems);
   }

--- a/src/models/amun.h
+++ b/src/models/amun.h
@@ -36,7 +36,7 @@ public:
   }
 
   void load(Ptr<ExpressionGraph> graph,
-            const std::string& name,
+            const std::vector<io::Item>& items,
             bool /*markedReloaded*/ = true) override {
     std::map<std::string, std::string> nameMap
         = {{"decoder_U", "decoder_cell1_U"},
@@ -89,9 +89,9 @@ public:
     if(opt<bool>("tied-embeddings-src") || opt<bool>("tied-embeddings-all"))
       nameMap["Wemb"] = "Wemb";
 
-    LOG(info, "Loading model from {}", name);
+    LOG(info, "[amun] Loading model from item");
     // load items from .npz file
-    auto ioItems = io::loadItems(name);
+    auto ioItems = items;
     // map names and remove a dummy matrices
     for(auto it = ioItems.begin(); it != ioItems.end();) {
       if(it->name == "decoder_c_tt") {
@@ -109,6 +109,15 @@ public:
     }
     // load items into the graph
     graph->load(ioItems);
+  }
+
+  void load(Ptr<ExpressionGraph> graph,
+            const std::string& name,
+            bool /*markReloaded*/ = true) override {
+    LOG(info, "[amun] Loading model from file {}", name);
+    // load items from .npz file
+    auto ioItems = io::loadItems(name);
+    load(graph, ioItems);
   }
 
   void save(Ptr<ExpressionGraph> graph,

--- a/src/models/costs.h
+++ b/src/models/costs.h
@@ -320,6 +320,12 @@ public:
       : encdec_(encdec), cost_(cost) {}
 
   virtual void load(Ptr<ExpressionGraph> graph,
+                    const std::vector<io::Item>& items,
+                    bool markedReloaded = true) override {
+    encdec_->load(graph, items, markedReloaded);
+  }
+
+  virtual void load(Ptr<ExpressionGraph> graph,
                     const std::string& name,
                     bool markedReloaded = true) override {
     encdec_->load(graph, name, markedReloaded);

--- a/src/models/costs.h
+++ b/src/models/costs.h
@@ -322,6 +322,7 @@ public:
   virtual void load(Ptr<ExpressionGraph> graph,
                     const std::vector<io::Item>& items,
                     bool markedReloaded = true) override {
+    LOG(info, "[stepwise] encdec via items");
     encdec_->load(graph, items, markedReloaded);
   }
 

--- a/src/models/costs.h
+++ b/src/models/costs.h
@@ -322,7 +322,6 @@ public:
   virtual void load(Ptr<ExpressionGraph> graph,
                     const std::vector<io::Item>& items,
                     bool markedReloaded = true) override {
-    LOG(info, "[stepwise] encdec via items");
     encdec_->load(graph, items, markedReloaded);
   }
 

--- a/src/models/encoder_decoder.cpp
+++ b/src/models/encoder_decoder.cpp
@@ -142,6 +142,12 @@ std::string EncoderDecoder::getModelParametersAsString() {
 }
 
 void EncoderDecoder::load(Ptr<ExpressionGraph> graph,
+                          const std::vector<io::Item>& items,
+                          bool markedReloaded) {
+  graph->load(items, markedReloaded && !opt<bool>("ignore-model-config", false));
+}
+
+void EncoderDecoder::load(Ptr<ExpressionGraph> graph,
                           const std::string& name,
                           bool markedReloaded) {
   graph->load(name, markedReloaded && !opt<bool>("ignore-model-config", false));

--- a/src/models/encoder_decoder.h
+++ b/src/models/encoder_decoder.h
@@ -12,6 +12,11 @@ namespace marian {
 class IEncoderDecoder : public models::IModel {
 public:
   virtual ~IEncoderDecoder() {}
+
+  virtual void load(Ptr<ExpressionGraph> graph,
+                    const std::vector<io::Item>& items,
+                    bool markedReloaded = true){};
+
   virtual void load(Ptr<ExpressionGraph> graph,
                     const std::string& name,
                     bool markedReloaded = true) override
@@ -90,6 +95,10 @@ public:
   std::vector<Ptr<DecoderBase>>& getDecoders();
 
   void push_back(Ptr<DecoderBase> decoder);
+
+  virtual void load(Ptr<ExpressionGraph> graph,
+                    const std::vector<io::Item>& items,
+                    bool markedReloaded = true) override;
 
   virtual void load(Ptr<ExpressionGraph> graph,
                     const std::string& name,

--- a/src/models/encoder_decoder.h
+++ b/src/models/encoder_decoder.h
@@ -15,7 +15,7 @@ public:
 
   virtual void load(Ptr<ExpressionGraph> graph,
                     const std::vector<io::Item>& items,
-                    bool markedReloaded = true){};
+                    bool markedReloaded = true) = 0;
 
   virtual void load(Ptr<ExpressionGraph> graph,
                     const std::string& name,

--- a/src/models/nematus.h
+++ b/src/models/nematus.h
@@ -26,11 +26,11 @@ public:
   }
 
   void load(Ptr<ExpressionGraph> graph,
-            const std::string& name,
+            const std::vector<io::Item>& items,
             bool /*markReloaded*/ = true) override {
-    LOG(info, "Loading model from {}", name);
+    LOG(info, "[nematus] Loading model from item");
     // load items from .npz file
-    auto ioItems = io::loadItems(name);
+    auto ioItems = items;
     // map names and remove a dummy matrix 'decoder_c_tt' from items to avoid creating isolated node
     for(auto it = ioItems.begin(); it != ioItems.end();) {
       if(it->name == "decoder_c_tt") {
@@ -48,6 +48,15 @@ public:
     }
     // load items into the graph
     graph->load(ioItems);
+  }
+
+  void load(Ptr<ExpressionGraph> graph,
+            const std::string& name,
+            bool /*markReloaded*/ = true) override {
+    LOG(info, "[nematus] Loading model from file {}", name);
+    // load items from .npz file
+    auto ioItems = io::loadItems(name);
+    load(graph, ioItems);
   }
 
   void save(Ptr<ExpressionGraph> graph,

--- a/src/models/nematus.h
+++ b/src/models/nematus.h
@@ -28,8 +28,6 @@ public:
   void load(Ptr<ExpressionGraph> graph,
             const std::vector<io::Item>& items,
             bool /*markReloaded*/ = true) override {
-    LOG(info, "[nematus] Loading model from item");
-    // load items from .npz file
     auto ioItems = items;
     // map names and remove a dummy matrix 'decoder_c_tt' from items to avoid creating isolated node
     for(auto it = ioItems.begin(); it != ioItems.end();) {
@@ -53,8 +51,6 @@ public:
   void load(Ptr<ExpressionGraph> graph,
             const std::string& name,
             bool /*markReloaded*/ = true) override {
-    LOG(info, "[nematus] Loading model from file {}", name);
-    // load items from .npz file
     auto ioItems = io::loadItems(name);
     load(graph, ioItems);
   }

--- a/src/translator/scorers.cpp
+++ b/src/translator/scorers.cpp
@@ -5,6 +5,28 @@ namespace marian {
 
 Ptr<Scorer> scorerByType(const std::string& fname,
                          float weight,
+                         std::vector<io::Item> items,
+                         Ptr<Options> options) {
+  options->set("inference", true);
+  std::string type = options->get<std::string>("type");
+
+  // @TODO: solve this better
+  if(type == "lm" && options->has("input")) {
+    size_t index = options->get<std::vector<std::string>>("input").size();
+    options->set("index", index);
+  }
+
+  bool skipCost = options->get<bool>("skip-cost");
+  auto encdec = models::createModelFromOptions(
+      options, skipCost ? models::usage::raw : models::usage::translation);
+
+  LOG(info, "Loading scorer of type {} as feature {}", type, fname);
+
+  return New<ScorerWrapper>(encdec, fname, weight, items);
+}
+
+Ptr<Scorer> scorerByType(const std::string& fname,
+                         float weight,
                          const std::string& model,
                          Ptr<Options> options) {
   options->set("inference", true);
@@ -45,6 +67,58 @@ Ptr<Scorer> scorerByType(const std::string& fname,
   LOG(info, "Loading scorer of type {} as feature {}", type, fname);
 
   return New<ScorerWrapper>(encdec, fname, weight, ptr);
+}
+
+std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options, const std::vector<std::vector<io::Item>> models) {
+  std::vector<Ptr<Scorer>> scorers;
+
+  // auto models = options->get<std::vector<std::string>>("models");
+
+  std::vector<float> weights(models.size(), 1.f);
+  if(options->hasAndNotEmpty("weights"))
+    weights = options->get<std::vector<float>>("weights");
+
+  bool isPrevRightLeft = false;  // if the previous model was a right-to-left model
+  size_t i = 0;
+  for(auto items : models) {
+    std::string fname = "F" + std::to_string(i);
+
+    // load options specific for the scorer
+    auto modelOptions = New<Options>(options->clone());
+    try {
+      if(!options->get<bool>("ignore-model-config")) {
+        YAML::Node modelYaml;
+        io::getYamlFromModel(modelYaml, "special:model.yml", items);
+
+        if(!modelYaml.IsNull()) {
+          LOG(info, "Loaded model config");
+          modelOptions->merge(modelYaml, true);
+        }
+        else {
+          LOG(warn, "No model settings found in model file");
+        }
+      }
+    } catch(std::runtime_error&) {
+      LOG(warn, "No model settings found in model file");
+    }
+
+    // l2r and r2l cannot be used in the same ensemble
+    if(models.size() > 1 && modelOptions->has("right-left")) {
+      if(i == 0) {
+        isPrevRightLeft = modelOptions->get<bool>("right-left");
+      } else {
+        // abort as soon as there are two consecutive models with opposite directions
+        ABORT_IF(isPrevRightLeft != modelOptions->get<bool>("right-left"),
+                 "Left-to-right and right-to-left models cannot be used together in ensembles");
+        isPrevRightLeft = modelOptions->get<bool>("right-left");
+      }
+    }
+
+    scorers.push_back(scorerByType(fname, weights[i], items, modelOptions));
+    i++;
+  }
+
+  return scorers;
 }
 
 std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options) {

--- a/src/translator/scorers.cpp
+++ b/src/translator/scorers.cpp
@@ -27,28 +27,6 @@ Ptr<Scorer> scorerByType(const std::string& fname,
 
 Ptr<Scorer> scorerByType(const std::string& fname,
                          float weight,
-                         const std::string& model,
-                         Ptr<Options> options) {
-  options->set("inference", true);
-  std::string type = options->get<std::string>("type");
-
-  // @TODO: solve this better
-  if(type == "lm" && options->has("input")) {
-    size_t index = options->get<std::vector<std::string>>("input").size();
-    options->set("index", index);
-  }
-
-  bool skipCost = options->get<bool>("skip-cost");
-  auto encdec = models::createModelFromOptions(
-      options, skipCost ? models::usage::raw : models::usage::translation);
-
-  LOG(info, "Loading scorer of type {} as feature {}", type, fname);
-
-  return New<ScorerWrapper>(encdec, fname, weight, model);
-}
-
-Ptr<Scorer> scorerByType(const std::string& fname,
-                         float weight,
                          const void* ptr,
                          Ptr<Options> options) {
   options->set("inference", true);
@@ -108,53 +86,6 @@ std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options, const std::vector<s
     }
 
     scorers.push_back(scorerByType(fname, weights[i], items, modelOptions));
-    i++;
-  }
-
-  return scorers;
-}
-
-std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options) {
-  std::vector<Ptr<Scorer>> scorers;
-
-  auto models = options->get<std::vector<std::string>>("models");
-
-  std::vector<float> weights(models.size(), 1.f);
-  if(options->hasAndNotEmpty("weights"))
-    weights = options->get<std::vector<float>>("weights");
-
-  bool isPrevRightLeft = false;  // if the previous model was a right-to-left model
-  size_t i = 0;
-  for(auto model : models) {
-    std::string fname = "F" + std::to_string(i);
-
-    // load options specific for the scorer
-    auto modelOptions = New<Options>(options->clone());
-    if(!options->get<bool>("ignore-model-config")) {
-      YAML::Node modelYaml;
-      io::getYamlFromModel(modelYaml, "special:model.yml", model);
-      if(!modelYaml.IsNull()) {
-        LOG(info, "Loaded model config");
-        modelOptions->merge(modelYaml, true);
-      }
-      else {
-        LOG(warn, "No model settings found in model file");
-      }
-    }
-
-    // l2r and r2l cannot be used in the same ensemble
-    if(models.size() > 1 && modelOptions->has("right-left")) {
-      if(i == 0) {
-        isPrevRightLeft = modelOptions->get<bool>("right-left");
-      } else {
-        // abort as soon as there are two consecutive models with opposite directions
-        ABORT_IF(isPrevRightLeft != modelOptions->get<bool>("right-left"),
-                 "Left-to-right and right-to-left models cannot be used together in ensembles");
-        isPrevRightLeft = modelOptions->get<bool>("right-left");
-      }
-    }
-
-    scorers.push_back(scorerByType(fname, weights[i], model, modelOptions));
     i++;
   }
 

--- a/src/translator/scorers.cpp
+++ b/src/translator/scorers.cpp
@@ -72,8 +72,6 @@ Ptr<Scorer> scorerByType(const std::string& fname,
 std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options, const std::vector<std::vector<io::Item>> models) {
   std::vector<Ptr<Scorer>> scorers;
 
-  // auto models = options->get<std::vector<std::string>>("models");
-
   std::vector<float> weights(models.size(), 1.f);
   if(options->hasAndNotEmpty("weights"))
     weights = options->get<std::vector<float>>("weights");
@@ -85,21 +83,16 @@ std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options, const std::vector<s
 
     // load options specific for the scorer
     auto modelOptions = New<Options>(options->clone());
-    try {
-      if(!options->get<bool>("ignore-model-config")) {
-        YAML::Node modelYaml;
-        io::getYamlFromModel(modelYaml, "special:model.yml", items);
-
-        if(!modelYaml.IsNull()) {
-          LOG(info, "Loaded model config");
-          modelOptions->merge(modelYaml, true);
-        }
-        else {
-          LOG(warn, "No model settings found in model file");
-        }
+    if(!options->get<bool>("ignore-model-config")) {
+      YAML::Node modelYaml;
+      io::getYamlFromModel(modelYaml, "special:model.yml", items);
+      if(!modelYaml.IsNull()) {
+        LOG(info, "Loaded model config");
+        modelOptions->merge(modelYaml, true);
       }
-    } catch(std::runtime_error&) {
-      LOG(warn, "No model settings found in model file");
+      else {
+        LOG(warn, "No model settings found in model file");
+      }
     }
 
     // l2r and r2l cannot be used in the same ensemble
@@ -137,14 +130,16 @@ std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options) {
 
     // load options specific for the scorer
     auto modelOptions = New<Options>(options->clone());
-    try {
-      if(!options->get<bool>("ignore-model-config")) {
-        YAML::Node modelYaml;
-        io::getYamlFromModel(modelYaml, "special:model.yml", model);
+    if(!options->get<bool>("ignore-model-config")) {
+      YAML::Node modelYaml;
+      io::getYamlFromModel(modelYaml, "special:model.yml", model);
+      if(!modelYaml.IsNull()) {
+        LOG(info, "Loaded model config");
         modelOptions->merge(modelYaml, true);
       }
-    } catch(std::runtime_error&) {
-      LOG(warn, "No model settings found in model file");
+      else {
+        LOG(warn, "No model settings found in model file");
+      }
     }
 
     // l2r and r2l cannot be used in the same ensemble
@@ -179,14 +174,16 @@ std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options, const std::vector<c
 
     // load options specific for the scorer
     auto modelOptions = New<Options>(options->clone());
-    try {
-      if(!options->get<bool>("ignore-model-config")) {
-        YAML::Node modelYaml;
-        io::getYamlFromModel(modelYaml, "special:model.yml", ptr);
+    if(!options->get<bool>("ignore-model-config")) {
+      YAML::Node modelYaml;
+      io::getYamlFromModel(modelYaml, "special:model.yml", ptr);
+      if(!modelYaml.IsNull()) {
+        LOG(info, "Loaded model config");
         modelOptions->merge(modelYaml, true);
       }
-    } catch(std::runtime_error&) {
-      LOG(warn, "No model settings found in model file");
+      else {
+        LOG(warn, "No model settings found in model file");
+      }
     }
 
     scorers.push_back(scorerByType(fname, weights[i], ptr, modelOptions));

--- a/src/translator/scorers.cpp
+++ b/src/translator/scorers.cpp
@@ -92,6 +92,17 @@ std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options, const std::vector<s
   return scorers;
 }
 
+std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options) {
+  std::vector<std::vector<io::Item>> model_items;
+  auto models = options->get<std::vector<std::string>>("models");
+  for(auto model : models) {
+    auto items = io::loadItems(model);
+    model_items.push_back(std::move(items));
+  }
+
+  return createScorers(options, model_items);
+}
+
 std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options, const std::vector<const void*>& ptrs) {
   std::vector<Ptr<Scorer>> scorers;
 

--- a/src/translator/scorers.h
+++ b/src/translator/scorers.h
@@ -107,7 +107,7 @@ public:
 
   virtual void init(Ptr<ExpressionGraph> graph) override {
     graph->switchParams(getName());
-    if(items_.size() > 0)
+    if(!items_.empty())
       encdec_->load(graph, items_);
     else if(ptr_)
       encdec_->mmap(graph, ptr_);

--- a/src/translator/scorers.h
+++ b/src/translator/scorers.h
@@ -166,6 +166,7 @@ Ptr<Scorer> scorerByType(const std::string& fname,
 
 
 std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options);
+std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options, const std::vector<std::vector<io::Item>> models);
 
 Ptr<Scorer> scorerByType(const std::string& fname,
                          float weight,

--- a/src/translator/scorers.h
+++ b/src/translator/scorers.h
@@ -73,9 +73,19 @@ class ScorerWrapper : public Scorer {
 private:
   Ptr<IEncoderDecoder> encdec_;
   std::string fname_;
+  std::vector<io::Item> items_;
   const void* ptr_;
 
 public:
+  ScorerWrapper(Ptr<models::IModel> encdec,
+                const std::string& name,
+                float weight,
+                std::vector<io::Item>& items)
+      : Scorer(name, weight),
+        encdec_(std::static_pointer_cast<IEncoderDecoder>(encdec)),
+        items_(items),
+        ptr_{0} {}
+
   ScorerWrapper(Ptr<models::IModel> encdec,
                 const std::string& name,
                 float weight,
@@ -97,7 +107,9 @@ public:
 
   virtual void init(Ptr<ExpressionGraph> graph) override {
     graph->switchParams(getName());
-    if(ptr_)
+    if(items_.size() > 0)
+      encdec_->load(graph, items_);
+    else if(ptr_)
       encdec_->mmap(graph, ptr_);
     else
       encdec_->load(graph, fname_);
@@ -143,9 +155,15 @@ public:
 };
 
 Ptr<Scorer> scorerByType(const std::string& fname,
+                        float weight,
+                        std::vector<io::Item> items,
+                        Ptr<Options> options);
+
+Ptr<Scorer> scorerByType(const std::string& fname,
                          float weight,
                          const std::string& model,
                          Ptr<Options> config);
+
 
 std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options);
 

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -263,7 +263,6 @@ public:
       model_items_.push_back(std::move(items));
     }
 
-
     // initialize scorers
     for(auto device : devices) {
       auto graph = New<ExpressionGraph>(true);

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -255,6 +255,15 @@ public:
     auto devices = Config::getDevices(options_);
     numDevices_ = devices.size();
 
+    // preload models
+    std::vector<std::vector<io::Item>> model_items_;
+    auto models = options->get<std::vector<std::string>>("models");
+    for(auto model : models) {
+      auto items = io::loadItems(model);
+      model_items_.push_back(std::move(items));
+    }
+
+
     // initialize scorers
     for(auto device : devices) {
       auto graph = New<ExpressionGraph>(true);
@@ -266,7 +275,7 @@ public:
       graph->reserveWorkspaceMB(options_->get<size_t>("workspace"));
       graphs_.push_back(graph);
 
-      auto scorers = createScorers(options_);
+      auto scorers = createScorers(options_, model_items_);
       for(auto scorer : scorers) {
         scorer->init(graph);
         if(shortlistGenerator_)

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -77,7 +77,7 @@ public:
     graphs_.resize(numDevices_);
 
     auto models = options->get<std::vector<std::string>>("models");
-    if(options_->get<bool>("model-mmap")) {
+    if(options_->get<bool>("model-mmap", false)) {
       for(auto model : models) {
         ABORT_IF(!io::isBin(model), "Non-binarized models cannot be mmapped");
         model_mmaps_.push_back(std::move(mio::mmap_source(model)));
@@ -102,7 +102,7 @@ public:
         graphs_[id] = graph;
 
         std::vector<Ptr<Scorer>> scorers;
-        if(options_->get<bool>("model-mmap")) {
+        if(options_->get<bool>("model-mmap", false)) {
           scorers = createScorers(options_, model_mmaps_);
         }
         else {

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -78,9 +78,7 @@ public:
     if(options_->get<bool>("model-mmap")) {
       auto models = options->get<std::vector<std::string>>("models");
       for(auto model : models) {
-        marian::filesystem::Path modelPath(model);
-        ABORT_IF(modelPath.extension() != marian::filesystem::Path(".bin"),
-                "Non-binarized models cannot be mmapped");
+        ABORT_IF(!io::isBin(model), "Non-binarized models cannot be mmapped");
         mmaps_.push_back(std::move(mio::mmap_source(model)));
       }
     }

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -19,12 +19,7 @@
 #include "translator/scorers.h"
 
 // currently for diagnostics only, will try to mmap files ending in *.bin suffix when enabled.
-// @TODO: add this as an actual feature.
-#define MMAP 0
-
-#if MMAP
 #include "3rd_party/mio/mio.hpp"
-#endif
 
 namespace marian {
 
@@ -41,9 +36,7 @@ private:
 
   size_t numDevices_;
 
-#if MMAP
   std::vector<mio::mmap_source> mmaps_;
-#endif
 
 public:
   Translate(Ptr<Options> options)
@@ -82,15 +75,15 @@ public:
     scorers_.resize(numDevices_);
     graphs_.resize(numDevices_);
 
-#if MMAP
-    auto models = options->get<std::vector<std::string>>("models");
-    for(auto model : models) {
-      marian::filesystem::Path modelPath(model);
-      ABORT_IF(modelPath.extension() != marian::filesystem::Path(".bin"),
-              "Non-binarized models cannot be mmapped");
-      mmaps_.push_back(std::move(mio::mmap_source(model)));
+    if(options_->get<bool>("model-mmap")) {
+      auto models = options->get<std::vector<std::string>>("models");
+      for(auto model : models) {
+        marian::filesystem::Path modelPath(model);
+        ABORT_IF(modelPath.extension() != marian::filesystem::Path(".bin"),
+                "Non-binarized models cannot be mmapped");
+        mmaps_.push_back(std::move(mio::mmap_source(model)));
+      }
     }
-#endif
 
     size_t id = 0;
     for(auto device : devices) {
@@ -103,11 +96,14 @@ public:
         graph->reserveWorkspaceMB(options_->get<size_t>("workspace"));
         graphs_[id] = graph;
 
-#if MMAP
-        auto scorers = createScorers(options_, mmaps_);
-#else
-        auto scorers = createScorers(options_);
-#endif
+        std::vector<Ptr<Scorer>> scorers;
+        if(options_->get<bool>("model-mmap")) {
+          scorers = createScorers(options_, mmaps_);
+        }
+        else {
+          scorers = createScorers(options_);
+        }
+
         for(auto scorer : scorers) {
           scorer->init(graph);
           if(shortlistGenerator_)

--- a/src/translator/translator.h
+++ b/src/translator/translator.h
@@ -80,7 +80,7 @@ public:
     if(options_->get<bool>("model-mmap", false)) {
       for(auto model : models) {
         ABORT_IF(!io::isBin(model), "Non-binarized models cannot be mmapped");
-        model_mmaps_.push_back(std::move(mio::mmap_source(model)));
+        model_mmaps_.push_back(mio::mmap_source(model));
       }
     }
     else {


### PR DESCRIPTION
### Description
Commits rebased from marian-nmt#860. Instead of loading each model twice per thread, it loads the model once. 

**Note: this PR adds a CLI option for MMAP (consistent with upstream) but is off by default - this shouldn't interfere with the changes to disable MMAP in this repository.**

List of changes:
- Adds `--model-mmap` as a command line option (uses mio)
- Preloads model to Item vector before creating scorers
- try-catch when loading model YAML is replaced with if-else
- Extended `IEncoderDecoder` to load from Item vector
- `Amun` and `Nematus` models load overload for Item vector

Added dependencies: none

### How to test
Describe how to test your changes, adding command line examples and sample input/output files if relevant.
Point to unit tests or regression tests covering the changes if they have been added.

Describe how you have tested your code, including OS and the cmake command.

### Checklist

- [ ] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md
