### PR TITLE
Fix binary shortlist to use vocab size

### DIFF
--- a/src/data/shortlist.cpp
+++ b/src/data/shortlist.cpp
@@ -319,19 +319,18 @@ void BinaryShortlistGenerator::dump(const std::string& fileName) const {
 void BinaryShortlistGenerator::import(const std::string& filename, double threshold) {
   io::InputFileStream in(filename);
   std::string src, trg;
-
-  // Read text file
-  std::vector<std::unordered_map<WordIndex, float>> srcTgtProbTable;
+  
+  std::vector<std::unordered_map<WordIndex, float>> srcTgtProbTable(srcVocab_->size());
   float prob;
 
+  // Read text file
   while(in >> trg >> src >> prob) {
     if(src == "NULL" || trg == "NULL")
       continue;
 
     auto sId = (*srcVocab_)[src].toWordIndex();
     auto tId = (*trgVocab_)[trg].toWordIndex();
-    if(srcTgtProbTable.size() <= sId)
-      srcTgtProbTable.resize(sId + 1);
+
     if(srcTgtProbTable[sId][tId] < prob)
       srcTgtProbTable[sId][tId] = prob;
   }


### PR DESCRIPTION
### Description

The generation of the shortlist requires the size of the vocabulary. Before the modification, the size is measured following the legacy LexicalShortlistGenerator. However, it gives the wrong size when (max source word ID) < (vocabulary size - 1). And the program crashes (@jelmervdl Thanks for pointing out). The modification retrieves the size directly to avoid such a problem and to avoid resizing.

Added dependencies: none

### Checklist

- [x] I have tested the code manually
- [x] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
