### PR TITLE
Print intgemm::kCPU at runtime with --gemm-highest-arch

### DIFF
--- a/src/common/config_parser.cpp
+++ b/src/common/config_parser.cpp
@@ -10,6 +10,7 @@
 #include "common/options.h"
 #include "common/regex.h"
 #include "common/utils.h"
+#include "3rd_party/intgemm/intgemm/types.h"
 #include <algorithm>
 #include <set>
 #include <stdexcept>
@@ -944,6 +945,7 @@ void ConfigParser::addSuboptionsIntgemm(cli::CLIWrapper& cli) {
       "Use lower precision for the GEMM operations only. Supported values: float32, int16, int8, int8shift, int8shiftAlpha, int8shiftAll, int8shiftAlphaAll", "float32");
   cli.add<bool>("--dump-quantmult",
       "Dump the quantization multipliers of activation matrices during an avarage run. To be used to precompute alphas for ---gemm-precision int8shiftAlpha or int8shiftAlphaAll.");
+  cli.add<std::string>("--gemm-highest-arch", "Print highest available cpu arch for intgemm and exit.")->implicit_val("auto");
   // clang-format on
 }
 void ConfigParser::addSuboptionsQuantization(cli::CLIWrapper& cli) {
@@ -992,6 +994,12 @@ Ptr<Options> ConfigParser::parseOptions(int argc, char** argv, bool doValidate) 
 #else // _MSC_VER
     ABORT("build-info is not available on MSVC based build.");
 #endif // _MSC_VER
+  }
+
+  auto gemmInfo = get<std::string>("gemm-highest-arch");
+  if(!gemmInfo.empty() && gemmInfo != "false"){
+      std::cout << static_cast<int>(intgemm::kCPU) << "\n";
+      exit(0);
   }
 
   // get paths to extra config files


### PR DESCRIPTION
### Description

Adds a `--gemm-highest-arch` option which prints the activated `intgemm::kCPU`. This is set at runtime based on available hardware and also an environment variable override using `INTGEMM_CPUID`. Inferring the activated codepath is necessary to compare exactly against expected output at BRT. 

I'm mimicking `--build-info` for most of the implementation.

Added dependencies: none

### How to test

```
jphilip@var:~/code/marian-dev/build$ ./marian-decoder --gemm-highest-arch
5
```

Also in use in the following run: https://github.com/browsermt/bergamot-translator/pull/184/checks?check_run_id=2766135535

### Checklist

- [ ] I have tested the code manually
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
