### PR TITLE
Wasm builds without SharedArrayBuffer

### DIFF
--- a/.github/workflows/wasm-customized_marian-macos.yml
+++ b/.github/workflows/wasm-customized_marian-macos.yml
@@ -13,7 +13,9 @@ jobs:
 
     steps:
     - name: Setup Emscripten toolchain
-      uses: mymindstorm/setup-emsdk@v8
+      uses: mymindstorm/setup-emsdk@v9
+      with:
+          version: 2.0.9
 
     - name: Verify Emscripten setup
       run: emcc -v

--- a/.github/workflows/wasm-customized_marian-ubuntu.yml
+++ b/.github/workflows/wasm-customized_marian-ubuntu.yml
@@ -13,7 +13,9 @@ jobs:
 
     steps:
     - name: Setup Emscripten toolchain
-      uses: mymindstorm/setup-emsdk@v8
+      uses: mymindstorm/setup-emsdk@v9
+      with:
+          version: 2.0.9
 
     - name: Verify Emscripten setup
       run: emcc -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,8 +260,10 @@ else(MSVC)
   endif(CMAKE_COMPILER_IS_GNUCC)
 
   if(COMPILE_WASM)
-    set(PTHREAD_FLAG "-pthread")
-    set(DISABLE_PTHREAD_MEMGROWTH_WARNING -Wno-error=pthreads-mem-growth)
+    if(USE_THREADS)
+      set(PTHREAD_FLAG "-pthread")
+      set(DISABLE_PTHREAD_MEMGROWTH_WARNING -Wno-error=pthreads-mem-growth)
+    endif(USE_THREADS)
     set(CMAKE_CXX_FLAGS                 "-std=c++11 ${PTHREAD_FLAG} ${CMAKE_GCC_FLAGS} -fPIC ${DISABLE_GLOBALLY} ${INTRINSICS}")
     set(CMAKE_CXX_FLAGS_RELEASE         "-O3 -s WASM=1 -s ASSERTIONS=0 -s DISABLE_EXCEPTION_CATCHING=1 -s LLD_REPORT_UNDEFINED -s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1 -g2 ${DISABLE_PTHREAD_MEMGROWTH_WARNING} -funroll-loops")
     # Disabling Pthreads + memory growth warning to be an error

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ CMAKE_DEPENDENT_OPTION(COMPILE_WITHOUT_EXCEPTIONS "Compile without exceptions" O
                        "USE_WASM_COMPATIBLE_SOURCE" OFF)
 
 if (USE_WASM_COMPATIBLE_SOURCE)
+  set(SPM_BUILD_LIBRARY_ONLY ON CACHE BOOL "Build only sentencepiece library (skip building executables)")
   add_compile_definitions(WASM_COMPATIBLE_SOURCE)
   # Setting USE_SSE2 definition to enable SSE2 specific code in "3rd_party/sse_mathfun.h" for wasm builds
   add_compile_definitions(USE_SSE2)
@@ -57,7 +58,6 @@ endif()
 
 if (COMPILE_WASM)
   add_compile_definitions(WASM)
-  set(SPM_BUILD_LIBRARY_ONLY ON CACHE BOOL "Build only sentencepiece library (skip building executables)")
   set(WORMHOLE ON CACHE BOOL "Use WASM wormhole in intgemm https://bugzilla.mozilla.org/show_bug.cgi?id=1672160")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 
 if (COMPILE_WASM)
   add_compile_definitions(WASM)
+  set(SPM_BUILD_LIBRARY_ONLY ON CACHE BOOL "Build only sentencepiece library (skip building executables)")
   set(WORMHOLE ON CACHE BOOL "Use WASM wormhole in intgemm https://bugzilla.mozilla.org/show_bug.cgi?id=1672160")
 endif()
 

--- a/src/3rd_party/CMakeLists.txt
+++ b/src/3rd_party/CMakeLists.txt
@@ -84,19 +84,24 @@ if(USE_SENTENCEPIECE)
 
   add_subdirectory(./sentencepiece)
   include_directories(./sentencepiece)
+  if (NOT USE_WASM_COMPATIBLE_SOURCE)
   set_target_properties(spm_encode spm_decode spm_train spm_normalize spm_export_vocab
     PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
+  endif()
+
+  list(APPEND SENTENCEPIECE_TARGETS sentencepiece-static sentencepiece_train-static)
+  if (NOT USE_WASM_COMPATIBLE_SOURCE)
+    list(APPEND SENTENCEPIECE_TARGETS spm_decode spm_encode spm_export_vocab spm_normalize spm_train)
+  endif()
 
   if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND (CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL 8.0 OR CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0))
-    foreach(t sentencepiece-static sentencepiece_train-static
-        spm_decode spm_encode spm_export_vocab spm_normalize spm_train)
+    foreach(t IN LISTS SENTENCEPIECE_TARGETS)
         set_property(TARGET ${t} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-class-memaccess")
     endforeach(t)
   endif()
 
   if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    foreach(t sentencepiece-static sentencepiece_train-static
-        spm_decode spm_encode spm_export_vocab spm_normalize spm_train)
+    foreach(t IN LISTS SENTENCEPIECE_TARGETS)
       set_property(TARGET ${t} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-tautological-compare -Wno-unused")
       if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 9.0)
         set_property(TARGET ${t} APPEND_STRING PROPERTY COMPILE_FLAGS " -Wno-range-loop-construct")


### PR DESCRIPTION
### Description
The PR enables running wasm port on browsers that don't enable SharedArrayBuffer. Detailed reasoning explained here: https://github.com/mozilla/bergamot-translator/issues/63

Fixes https://github.com/browsermt/marian-dev/issues/53

List of changes:
- Compile without `-pthreads` compilation flag for wasm
- Disable building sentencepiece executables for wasm builds (only libraries are required for wasm)
- Changed emsdk version in wasm specific github workflows to make it consistent across marian and bergamot-translator (see [here](https://github.com/browsermt/bergamot-translator/blob/main/.circleci/config.yml#L5))

Added dependencies: none

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
