### PR TITLE
Changing createLogger's signature to return loggers created

### DIFF
--- a/src/common/logging.cpp
+++ b/src/common/logging.cpp
@@ -65,9 +65,10 @@ bool setLoggingLevel(spdlog::logger& logger, std::string const level) {
 }
 
 static void setErrorHandlers();
-void createLoggers(const marian::Config* config) {
+std::vector<Logger> createLoggers(const marian::Config* config) {
   std::vector<std::string> generalLogs;
   std::vector<std::string> validLogs;
+  std::vector<Logger> loggers;
 
   if(config && !config->get<std::string>("log").empty()) {
     generalLogs.push_back(config->get<std::string>("log"));
@@ -84,12 +85,14 @@ void createLoggers(const marian::Config* config) {
 
   bool quiet = config && config->get<bool>("quiet");
   Logger general{createStderrLogger("general", "[%Y-%m-%d %T] %v", generalLogs, quiet)};
+  loggers.push_back(general);
   Logger valid{createStderrLogger("valid", "[%Y-%m-%d %T] [valid] %v", validLogs, quiet)};
+  loggers.push_back(valid);
 
   if(config && config->has("log-level")) {
     std::string loglevel = config->get<std::string>("log-level");
     if(!setLoggingLevel(*general, loglevel))
-      return;
+      return loggers;
     setLoggingLevel(*valid, loglevel);
   }
 
@@ -103,6 +106,7 @@ void createLoggers(const marian::Config* config) {
   }
 
   setErrorHandlers();
+  return loggers;
 }
 
 static void unhandledException() {

--- a/src/common/logging.h
+++ b/src/common/logging.h
@@ -171,5 +171,5 @@ void checkedLog(std::string logger, std::string level, Args... args) {
   }
 }
 
-void createLoggers(const marian::Config* options = nullptr);
+std::vector<Logger> createLoggers(const marian::Config* options = nullptr);
 void switchtoMultinodeLogging(std::string nodeIdStr);


### PR DESCRIPTION
For https://github.com/browsermt/bergamot-translator/pull/226. Changes a stateful hidden logger creation to something a client can manage creation and deletion off.