### PR TITLE
Import optimized gemm implementation when available for wasm target

### DIFF
--- a/wasm/import-gemm-module.js
+++ b/wasm/import-gemm-module.js
@@ -1,0 +1,25 @@
+
+/* Use an optimized gemm implementation if available, otherwise use the fallback
+ * implementation.
+ */
+function createWasmGemm() {
+    const OPTIMIZED_GEMM = "mozIntGemm";
+    const FALLBACK_GEMM =  "asm";
+
+    if (WebAssembly[OPTIMIZED_GEMM]) {
+        console.log(`Using optimized gemm (${OPTIMIZED_GEMM}) implementation`);
+        return new WebAssembly.Instance(WebAssembly[OPTIMIZED_GEMM](), {"": {memory: wasmMemory}}).exports;
+    }
+    else {
+        console.log(`Using fallback gemm implementation`);
+        return {
+            "int8_prepare_a": (...a) => Module[FALLBACK_GEMM]["int8PrepareAFallback"](...a),
+            "int8_prepare_b": (...a) => Module[FALLBACK_GEMM]["int8PrepareBFallback"](...a),
+            "int8_prepare_b_from_transposed": (...a) => Module[FALLBACK_GEMM]["int8PrepareBFromTransposedFallback"](...a),
+            "int8_prepare_b_from_quantized_transposed": (...a) => Module[FALLBACK_GEMM]["int8PrepareBFromQuantizedTransposedFallback"](...a),
+            "int8_prepare_bias": (...a) => Module[FALLBACK_GEMM]["int8PrepareBiasFallback"](...a),
+            "int8_multiply_and_add_bias": (...a) => Module[FALLBACK_GEMM]["int8MultiplyAndAddBiasFallback"](...a),
+            "int8_select_columns_of_b": (...a) => Module[FALLBACK_GEMM]["int8SelectColumnsOfBFallback"](...a)
+        }
+    }
+}

--- a/wasm/package-benchmark.sh
+++ b/wasm/package-benchmark.sh
@@ -28,14 +28,9 @@ sed -i.bak 's/return WebAssembly.instantiate(binary, info);/return WebAssembly.i
 sed -i.bak 's/var module = new WebAssembly.Module(bytes);/var module = new WebAssembly.Module(bytes, {simdWormhole:true});/g' marian-decoder.js
 echo "SUCCESS"
 
-echo "Polyfill the fallback integer (8-bit) gemm implementation from the main module"
-sed -i.bak 's/asmLibraryArg,/asmLibraryArg,"wasm_gemm":{\
-    "int8_prepare_a": (...a) => Module["asm"].int8PrepareAFallback(...a),\
-    "int8_prepare_b": (...a) => Module["asm"].int8PrepareBFallback(...a),\
-    "int8_prepare_b_from_transposed": (...a) => Module["asm"].int8PrepareBFromTransposedFallback(...a),\
-    "int8_prepare_b_from_quantized_transposed": (...a) => Module["asm"].int8PrepareBFromQuantizedTransposedFallback(...a),\
-    "int8_prepare_bias": (...a) => Module["asm"].int8PrepareBiasFallback(...a),\
-    "int8_multiply_and_add_bias": (...a) => Module["asm"].int8MultiplyAndAddBiasFallback(...a),\
-    "int8_select_columns_of_b": (...a) => Module["asm"].int8SelectColumnsOfBFallback(...a),\
-    },/g' marian-decoder.js
+echo "Importing integer (8-bit) gemm implementation"
+SCRIPT_ABSOLUTE_PATH="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
+sed -i.bak 's/"env"[[:space:]]*:[[:space:]]*asmLibraryArg,/"env": asmLibraryArg,\
+    "wasm_gemm": createWasmGemm(),/g' marian-decoder.js
+cat $SCRIPT_ABSOLUTE_PATH/import-gemm-module.js >> marian-decoder.js
 echo "SUCCESS"


### PR DESCRIPTION
### Description
Fixes a part of https://github.com/browsermt/bergamot-translator/issues/264 and the rest of https://github.com/browsermt/marian-dev/issues/63 as per https://github.com/browsermt/marian-dev/pull/64#issuecomment-970180351

List of changes:
- Added file `wasm/import-gemm-module.js` that houses the logic to import the optimized gemm when available, otherwise fallback gemm

Added dependencies: none

### How to test
Follow [README](https://github.com/browsermt/marian-dev/tree/master/wasm#readme) and do the inference in the browser console. The optimized gemm is called when run on locally compiled version of firefox browser that exports a dummy implementation for gemm intrinsics. This proves that the logic written here works correctly.

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
