### PR TITLE
Fix AVX2 detection on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Use target-agnostic matrix multiply interface for wasm builds and allow importing an implementation of this interface from separate wasm modules.
 
 ### Fixed
+- Fix AVX2 detection on macOS
 - Segfault of spm_train when compiled with -DUSE_STATIC_LIBS=ON seems to have gone away with update to newer SentencePiece version.
 - Fix bug causing certain reductions into scalars to be 0 on the GPU backend. Removed unnecessary warp shuffle instructions.
 - Do not apply dropout in embeddings layers during inference with dropout-src/trg

--- a/cmake/FindSSE.cmake
+++ b/cmake/FindSSE.cmake
@@ -74,9 +74,7 @@ IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
    ENDIF (AVX512_TRUE)
 
 ELSEIF(CMAKE_SYSTEM_NAME MATCHES "Darwin")
-   EXEC_PROGRAM("/usr/sbin/sysctl -n machdep.cpu.features" OUTPUT_VARIABLE
-      CPUINFO)
-
+   EXEC_PROGRAM("/usr/sbin/sysctl -n machdep.cpu.features machdep.cpu.leaf7_features" OUTPUT_VARIABLE CPUINFO)
    STRING(REGEX REPLACE "^.*[^S](SSE2).*$" "\\1" SSE_THERE ${CPUINFO})
    STRING(COMPARE EQUAL "SSE2" "${SSE_THERE}" SSE2_TRUE)
    IF (SSE2_TRUE)


### PR DESCRIPTION
Update AVX2 detection script to properly support macOS

### Description
This is a fix for Marian's FindSSE.cmake script: https://github.com/marian-nmt/marian-dev/issues/880

List of changes:
- also queries machdep.cpu.leaf7_features on macOS when searching for CPU features

Added dependencies: none

### How to test
```
mkdir build
cd build
cmake .. | fgrep AVX2
```

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
