### PR TITLE
Implement `getItem` as a specialised version of `loadItems`

### DIFF
--- a/src/common/binary.cpp
+++ b/src/common/binary.cpp
@@ -82,7 +82,6 @@ void loadItems(const void* current, std::vector<io::Item>& items, bool mapped) {
   get<char>(current, offset);
 
   for(int i = 0; i < numHeaders; ++i) {
-    std::cerr << "Decoding " << items[i].name << std::endl;
     //if(items[i].mapped && !isIntgemm(items[i].type)) { // memory-mapped, hence only set pointer. At the moment it intgemm matrices can't be used without processing
     //  items[i].ptr = get<char>(current, headers[i].dataLength);
     //} else { // reading into item data


### PR DESCRIPTION
`marian::createScorer()` calls `loadItems()` twice: once for looking for a special:model.yml entry, and once for the actual data. The first call is very expensive since it will decode & dequantize all entries just for a simple lookup of a text file.

This change copies some of the logic from `loadItems()` into `getItem()` to only process that one entry that it searches for. 

The alternative, passing the actual items down through `createScorer` and all the other users of the output of `loadItems()` would be better, but requires a far more intrusive change set that doesn't yield any additional performance benefit in the standard bergamot-translator use case.

Shaves off about 1 sec of the loading time on my machine. (Tested with a default (debug?) build of bergamot-translator that uses bundle loading, CPU has turbo-boosting disabled.)

Edit 2: Cold start-up + translation of a single sentence with HTML is 340ms now on my machine with a release build.