### PR TITLE
Pass `io::Item` by reference during scorer initialisation

### DIFF
--- a/src/common/binary.cpp
+++ b/src/common/binary.cpp
@@ -110,26 +110,26 @@ void loadItems(const std::string& fileName, std::vector<io::Item>& items) {
   loadItems(buf.data(), items, false);
 }
 
-io::Item getItem(const void* current, const std::string& varName) {
+io::Item &&getItem(const void* current, const std::string& varName) {
   std::vector<io::Item> items;
   loadItems(current, items);
 
   for(auto& item : items)
     if(item.name == varName)
-      return item;
+      return std::move(item);
 
-  return io::Item();
+  return std::move(io::Item());
 }
 
-io::Item getItem(const std::string& fileName, const std::string& varName) {
+io::Item &&getItem(const std::string& fileName, const std::string& varName) {
   std::vector<io::Item> items;
   loadItems(fileName, items);
 
   for(auto& item : items)
     if(item.name == varName)
-      return item;
+      return std::move(item);
 
-  return io::Item();
+  return std::move(io::Item());
 }
 
 void saveItems(const std::string& fileName,

--- a/src/common/binary.h
+++ b/src/common/binary.h
@@ -17,8 +17,8 @@ void loadItems(const void* current,
                bool mapped = false);
 void loadItems(const std::string& fileName, std::vector<io::Item>& items);
 
-io::Item getItem(const void* current, const std::string& vName);
-io::Item getItem(const std::string& fileName, const std::string& vName);
+io::Item &&getItem(const void* current, const std::string& vName);
+io::Item &&getItem(const std::string& fileName, const std::string& vName);
 
 void saveItems(const std::string& fileName, const std::vector<io::Item>& items);
 

--- a/src/common/io.cpp
+++ b/src/common/io.cpp
@@ -71,7 +71,8 @@ void getYamlFromModel(YAML::Node& yaml,
 void addMetaToItems(const std::string& meta,
                     const std::string& varName,
                     std::vector<io::Item>& items) {
-  Item item;
+  items.emplace_back();
+  Item &item = items.back();
   item.name = varName;
 
   // increase size by 1 to add \0
@@ -83,8 +84,6 @@ void addMetaToItems(const std::string& meta,
   item.bytes.back() = '\0';
 
   item.type = Type::int8;
-
-  items.push_back(item);
 }
 
 void loadItemsFromNpz(const std::string& fileName, std::vector<Item>& items) {

--- a/src/common/io_item.h
+++ b/src/common/io_item.h
@@ -17,7 +17,7 @@ struct Item {
   Shape shape;
   Type type{Type::float32};
 
-  bool valid{true};
+  bool valid{true}; // TODO debug remove
 
   Item() = default;
 
@@ -25,28 +25,14 @@ struct Item {
 
   Item &operator=(Item &&) = default;
 
-  Item(const Item &other)
-  : bytes(other.bytes)
-  , ptr(other.ptr)
-  , mapped(other.mapped)
-  , name(other.name)
-  , shape(other.shape)
-  , type(other.type)
-  , valid(other.valid) {
-    std::cerr << "Copy constructor io::Item(name=" << name << ")" << std::endl;
-    std::cerr << marian::getCallStack(/*skipLevels=*/0) << '\n' << std::endl;
-  }
-
   ~Item() {
-    valid = false;
+    valid = false; // TODO debug remove
   }
 
-  Item &operator=(const Item &other) {
-    // std::cerr << "Copy assignment: ";
-    Item copy(other);
-    *this = std::move(copy);
-    return *this;
-  }
+  // Copy constructor is marked private to only allow copies to be made very
+  // explicitly through clone() for the moment.
+
+  Item &operator=(const Item &other) = delete;
 
   const char* data() const {
     if(mapped)
@@ -120,6 +106,14 @@ struct Item {
 
     type = toType;
   }
+
+  Item &&clone() const {
+    Item copy(*this);
+    return std::move(copy);
+  }
+
+private:
+  Item(const Item &other) = default;
 };
 
 }  // namespace io

--- a/src/common/io_item.h
+++ b/src/common/io_item.h
@@ -17,6 +17,37 @@ struct Item {
   Shape shape;
   Type type{Type::float32};
 
+  bool valid{true};
+
+  Item() = default;
+
+  Item(Item &&) = default;
+
+  Item &operator=(Item &&) = default;
+
+  Item(const Item &other)
+  : bytes(other.bytes)
+  , ptr(other.ptr)
+  , mapped(other.mapped)
+  , name(other.name)
+  , shape(other.shape)
+  , type(other.type)
+  , valid(other.valid) {
+    std::cerr << "Copy constructor io::Item(name=" << name << ")" << std::endl;
+    std::cerr << marian::getCallStack(/*skipLevels=*/0) << '\n' << std::endl;
+  }
+
+  ~Item() {
+    valid = false;
+  }
+
+  Item &operator=(const Item &other) {
+    // std::cerr << "Copy assignment: ";
+    Item copy(other);
+    *this = std::move(copy);
+    return *this;
+  }
+
   const char* data() const {
     if(mapped)
       return ptr;

--- a/src/models/amun.h
+++ b/src/models/amun.h
@@ -89,20 +89,22 @@ public:
     if(opt<bool>("tied-embeddings-src") || opt<bool>("tied-embeddings-all"))
       nameMap["Wemb"] = "Wemb";
 
-    auto ioItems = items;
+    std::vector<io::Item> ioItems;
+    ioItems.reserve(items.size());
+
     // map names and remove a dummy matrices
-    for(auto it = ioItems.begin(); it != ioItems.end();) {
-      if(it->name == "decoder_c_tt") {
-        it = ioItems.erase(it);
-      } else if(it->name == "uidx") {
-        it = ioItems.erase(it);
-      } else if(it->name == "history_errs") {
-        it = ioItems.erase(it);
+    for(auto &&item : items) {
+      if(item.name == "decoder_c_tt") {
+        continue;
+      } else if(item.name == "uidx") {
+        continue;
+      } else if(item.name == "history_errs") {
+        continue;
       } else {
-        auto pair = nameMap.find(it->name);
-        if(pair != nameMap.end())
-          it->name = pair->second;
-        it++;
+        auto copy = item.clone();
+        auto pair = nameMap.find(item.name);
+        copy.name = pair != nameMap.end() ? pair->second : item.name;
+        ioItems.emplace_back(std::move(copy));
       }
     }
     // load items into the graph

--- a/src/models/nematus.h
+++ b/src/models/nematus.h
@@ -28,20 +28,21 @@ public:
   void load(Ptr<ExpressionGraph> graph,
             const std::vector<io::Item>& items,
             bool /*markReloaded*/ = true) override {
-    auto ioItems = items;
+    std::vector<io::Item> ioItems;
+    ioItems.reserve(items.size());
     // map names and remove a dummy matrix 'decoder_c_tt' from items to avoid creating isolated node
-    for(auto it = ioItems.begin(); it != ioItems.end();) {
-      if(it->name == "decoder_c_tt") {
-        it = ioItems.erase(it);
-      } else if(it->name == "uidx") {
-        it = ioItems.erase(it);
-      } else if(it->name == "history_errs") {
-        it = ioItems.erase(it);
+    for(auto &&item : items) {
+      if(item.name == "decoder_c_tt") {
+        continue;
+      } else if(item.name == "uidx") {
+        continue;
+      } else if(item.name == "history_errs") {
+        continue;
       } else {
-        auto pair = nameMap_.find(it->name);
-        if(pair != nameMap_.end())
-          it->name = pair->second;
-        it++;
+        auto copy = item.clone();
+        auto pair = nameMap_.find(item.name);
+        copy.name = pair != nameMap_.end() ? pair->second : item.name;
+        ioItems.emplace_back(std::move(copy));
       }
     }
     // load items into the graph

--- a/src/optimizers/optimizers.cpp
+++ b/src/optimizers/optimizers.cpp
@@ -56,7 +56,7 @@ void Adagrad::load(const std::string& name,
   std::vector<float> vGt;
 
   auto items = io::loadItems(name);
-  for(auto item : items) {
+  for(auto &&item : items) {
     // get the size of gt_
     auto totalSize = item.shape.elements();
 
@@ -111,7 +111,9 @@ void Adagrad::save(const std::string& name,
   item.bytes.resize(vGt.size() * sizeOf(item.type));
   std::copy((char*)vGt.data(), (char*)(vGt.data() + vGt.size()), item.bytes.begin());
 
-  io::saveItems(name, {item});
+  std::vector<io::Item> items;
+  items.push_back(std::move(item));
+  io::saveItems(name, items);
 }
 
 void Adagrad::resetStats() {
@@ -192,7 +194,7 @@ void Adam::load(const std::string& name,
   std::array<double, 2> vDenoms;
 
   auto items = io::loadItems(name);
-  for(auto item : items) {
+  for(auto &&item : items) {
     // get the size of mt_ and vt_, they are the same
     auto totalSize = item.shape.elements();
 
@@ -299,7 +301,12 @@ void Adam::save(const std::string& name,
   std::copy(
       (char*)vDenoms.data(), (char*)(vDenoms.data() + vDenoms.size()), itemDenoms.bytes.begin());
 
-  io::saveItems(name, {itemMt, itemVt, itemDenoms});
+  std::vector<io::Item> items;
+  items.reserve(3);
+  items.emplace_back(std::move(itemMt));
+  items.emplace_back(std::move(itemVt));
+  items.emplace_back(std::move(itemDenoms));
+  io::saveItems(name, items);
 }
 
 void Adam::resetStats() {

--- a/src/translator/scorers.cpp
+++ b/src/translator/scorers.cpp
@@ -5,7 +5,7 @@ namespace marian {
 
 Ptr<Scorer> scorerByType(const std::string& fname,
                          float weight,
-                         std::vector<io::Item> items,
+                         std::vector<io::Item> const &items,
                          Ptr<Options> options) {
   options->set("inference", true);
   std::string type = options->get<std::string>("type");
@@ -47,7 +47,7 @@ Ptr<Scorer> scorerByType(const std::string& fname,
   return New<ScorerWrapper>(encdec, fname, weight, ptr);
 }
 
-std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options, const std::vector<std::vector<io::Item>> models) {
+std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options, const std::vector<std::vector<io::Item>> &models) {
   std::vector<Ptr<Scorer>> scorers;
 
   std::vector<float> weights(models.size(), 1.f);
@@ -56,7 +56,7 @@ std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options, const std::vector<s
 
   bool isPrevRightLeft = false;  // if the previous model was a right-to-left model
   size_t i = 0;
-  for(auto items : models) {
+  for(auto &&items : models) {
     std::string fname = "F" + std::to_string(i);
 
     // load options specific for the scorer

--- a/src/translator/scorers.h
+++ b/src/translator/scorers.h
@@ -73,14 +73,15 @@ class ScorerWrapper : public Scorer {
 private:
   Ptr<IEncoderDecoder> encdec_;
   std::string fname_;
-  std::vector<io::Item> items_;
+  std::vector<io::Item> ownedItems_;
+  std::vector<io::Item> const &items_;
   const void* ptr_;
 
 public:
   ScorerWrapper(Ptr<models::IModel> encdec,
                 const std::string& name,
                 float weight,
-                std::vector<io::Item>& items)
+                const std::vector<io::Item>& items)
       : Scorer(name, weight),
         encdec_(std::static_pointer_cast<IEncoderDecoder>(encdec)),
         items_(items),
@@ -93,6 +94,7 @@ public:
       : Scorer(name, weight),
         encdec_(std::static_pointer_cast<IEncoderDecoder>(encdec)),
         fname_(fname),
+        items_(ownedItems_),
         ptr_{0} {}
 
   ScorerWrapper(Ptr<models::IModel> encdec,
@@ -101,13 +103,14 @@ public:
                 const void* ptr)
       : Scorer(name, weight),
         encdec_(std::static_pointer_cast<IEncoderDecoder>(encdec)),
+        items_(ownedItems_),
         ptr_{ptr} {}
 
   virtual ~ScorerWrapper() {}
 
   virtual void init(Ptr<ExpressionGraph> graph) override {
     graph->switchParams(getName());
-    if(!items_.empty())
+   if(!items_.empty())
       encdec_->load(graph, items_);
     else if(ptr_)
       encdec_->mmap(graph, ptr_);
@@ -156,7 +159,7 @@ public:
 
 Ptr<Scorer> scorerByType(const std::string& fname,
                         float weight,
-                        std::vector<io::Item> items,
+                        const std::vector<io::Item> &items,
                         Ptr<Options> options);
 
 Ptr<Scorer> scorerByType(const std::string& fname,
@@ -166,7 +169,7 @@ Ptr<Scorer> scorerByType(const std::string& fname,
 
 
 std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options);
-std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options, const std::vector<std::vector<io::Item>> models);
+std::vector<Ptr<Scorer>> createScorers(Ptr<Options> options, const std::vector<std::vector<io::Item>> &models);
 
 Ptr<Scorer> scorerByType(const std::string& fname,
                          float weight,


### PR DESCRIPTION
In #74 I noticed that `io::Item` is copied around a lot. In bergamot-translator we have `io::Item` contain a vector with the data, and all that data is then also copied around.

This change set attempts to use references instead of copies to prevent `io::Item` from being copied at all.

Only tested with bergamot-translator, and I made changes to that one as well to hold the `io::Item` vector at that level so it outlives initialisation (and can be shared across initialisation of multiple worker threads.) Probably breaks all the other initialisation paths (from file, from mmapped file). Hence draft.

Start-up time with the other optimisation pull requests also in place: ~150ms. Most time is now spend on zeroing the vectors of floats.

<img width="1904" alt="image" src="https://user-images.githubusercontent.com/198639/156145368-d1234af9-ca8f-42aa-ac56-bda6d9022fec.png">

Profile in WASM: https://share.firefox.dev/3McHelm (you'll have to zoom in to the 8.3 to 8.7s mark, before is mostly waiting on network IO)