### PR TITLE
Remove `static` precomputedAlphas bool in `affine` operation

### DIFF
--- a/src/tensors/cpu/intgemm_interface.h
+++ b/src/tensors/cpu/intgemm_interface.h
@@ -601,7 +601,7 @@ template<Type vtype>
 static inline Expr affine(Expr a, Expr b, Expr bias, bool transA, bool transB, float scale, float /* clipValue currently unused */ = 0.0f, bool shiftedBias=false) {
   Type bElementType = b->value_type();
   Expr aQuantMult = nullptr;
-  static bool precomputedAlphas = b->graph()->getBackend()->isPrecomputedAlpha();
+  bool precomputedAlphas = b->graph()->getBackend()->isPrecomputedAlpha();
   if (precomputedAlphas) { //Shifting here maybe should check?
     aQuantMult = Expression<fetchAlphaFromModelNodeOp>(b);
   } else {


### PR DESCRIPTION
This fixes a bug when switching between translation models that have different `gemm-precision` precisions specified in their configuration file. Which is why we never noticed it with our own student models (all `int8shiftAlpha`), but do see it now with the Ukrainian model (which uses just `int8`)

I tried to go through git blame to figure out why it was marked `static`.  @XapaJIaMnu please correct me if I'm wrong.
1. It was introduced in b75168dcc826ff0a74fac6d74ad067fc9fa977bc. Probably as an optimisation?
2. Then in 2b9e69dbb3f9d7a4c4d05269c9a4492cf49ec01b the other static variable, `static auto map = b->graph()->params()->getMap();` in `fetchAlphaFromModel(Expr b)` disappears when that function is rewritten into a `UnaryNodeOp`. But the one removed in this pull request remained. 