### PR TITLE
Patch int8PrepareBias to handle nullptr

### DIFF
--- a/src/tensors/cpu/wasm_intgemm_fallback.cpp
+++ b/src/tensors/cpu/wasm_intgemm_fallback.cpp
@@ -64,18 +64,18 @@ extern "C" void int8PrepareBiasFallback(const int8_t* input_B_prepared,
                                         const float* input_bias,
                                         float* output) {
   float unquant_factor = (-1) * ((127.0f / scale_A) * (127.0f / scale_B)) / (127.0f);
-  if (input_bias == nullptr) {
-    intgemm::Int8Shift::PrepareBias(
-        input_B_prepared,
-        width,
-        cols_B,
-        intgemm::callbacks::UnquantizeAndWrite(unquant_factor, output));
-  } else {
+  if (input_bias) {
     intgemm::Int8Shift::PrepareBias(
         input_B_prepared,
         width,
         cols_B,
         intgemm::callbacks::UnquantizeAndAddBiasAndWrite(unquant_factor, input_bias, output));
+  } else {
+    intgemm::Int8Shift::PrepareBias(
+        input_B_prepared,
+        width,
+        cols_B,
+        intgemm::callbacks::UnquantizeAndWrite(unquant_factor, output));
   }
 }
 

--- a/src/tensors/cpu/wasm_intgemm_fallback.cpp
+++ b/src/tensors/cpu/wasm_intgemm_fallback.cpp
@@ -64,11 +64,19 @@ extern "C" void int8PrepareBiasFallback(const int8_t* input_B_prepared,
                                         const float* input_bias,
                                         float* output) {
   float unquant_factor = (-1) * ((127.0f / scale_A) * (127.0f / scale_B)) / (127.0f);
-  intgemm::Int8Shift::PrepareBias(
-      input_B_prepared,
-      width,
-      cols_B,
-      intgemm::callbacks::UnquantizeAndAddBiasAndWrite(unquant_factor, input_bias, output));
+  if (input_bias == nullptr) {
+    intgemm::Int8Shift::PrepareBias(
+        input_B_prepared,
+        width,
+        cols_B,
+        intgemm::callbacks::UnquantizeAndWrite(unquant_factor, output));
+  } else {
+    intgemm::Int8Shift::PrepareBias(
+        input_B_prepared,
+        width,
+        cols_B,
+        intgemm::callbacks::UnquantizeAndAddBiasAndWrite(unquant_factor, input_bias, output));
+  }
 }
 
 extern "C" void int8MultiplyAndAddBiasFallback(const int8_t* input_A_prepared,


### PR DESCRIPTION
### Description
This fixes base student models not working with the wasm version of bergamot-translator.

`int8PrepareBias` is being called from both [`PrepareBiasForBNodeOp`](https://github.com/browsermt/marian-dev/blob/53c4f7e4537dbf7782c583e98f50e513f0a27541/src/tensors/cpu/intgemm_interface.h#L349) and [`PrepareFakeBiasForBNodeOp`](https://github.com/browsermt/marian-dev/blob/53c4f7e4537dbf7782c583e98f50e513f0a27541/src/tensors/cpu/intgemm_interface.h#L386). These are two different intgemm calls (callbacks differ) but they map to the same WASM surrogate function.

I'm using the fact that one of those calls has `bias_input = nullptr` as a way to differentiate between the two and call the correct intgemm function + callback pair in its implementation.

This will also need to be fixed in Mozilla's tree, @abhi-agg.

While on the topic of Mozilla's implementation, should [the bounds check](https://searchfox.org/mozilla-central/source/js/src/intgemm/IntegerGemmIntrinsic.cpp#271) in Mozilla's implementation also pick up nullptrs?

See issue #81 for a more detailed explanation.

List of changes:
- Fix `int8PrepareBias` fallback to call `intgemm::Int8Shift::PrepareBias` with the correct callback.
- Also fixes a nullptr dereference that would be crash-worthy were it to run natively.

### How to test
See #81 how I tested this. To test whether the fix itself works, easiest way would be:

1. Check out https://github.com/jelmervdl/firefox-translations
2. Change marian-dev submodule inside the bergamot-translator submodule to point to this branch
3. Build the wasm module. There is a build-docker-wasm.sh script in the repository. You can use that, but you have to make sure it doesn't re-checkout the dependencies. There is a cmake flag, GIT_SUBMODULE, that stops cmake from doing that.
4. After build-docker-wasm.sh (which also copies the .wasm and .js file) you need to go into the bergamot-translation-worker.js file and force it to always use the fallback implementation, not the optimised one in Firefox itself.
6. Add the `entries.reverse()` as mentioned here: https://github.com/jelmervdl/firefox-translations/issues/14. 
7. Go to German wikipedia for example, and translate it to English.

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
