### PR TITLE
Remove unused variable

### DIFF
--- a/src/training/communicator.h
+++ b/src/training/communicator.h
@@ -102,7 +102,6 @@ private:
       int totalSize = (int)graphs_[0]->params()->vals()->size();
       int shardSize = (int)ceil(totalSize / (float)graphs_.size());
 
-      int pos = 0;
       for(auto graph : graphs_) {
         int __size__ = std::min(shardSize, totalSize);
 
@@ -117,7 +116,6 @@ private:
         tmpTensors_.push_back(tmp);
 
         // move to next shard
-        pos += __size__;
         totalSize -= __size__;
       }
     }


### PR DESCRIPTION
### Description
Remove unused variable that the version of clang 13.1.6 (clang-1316.0.21.2) that XCode 13.3 ships with picks up on. Our compiler flags don't allow this.

```
marian-dev/src/training/communicator.h:105:11: error: variable 'pos' set but not used [-Werror,-Wunused-but-set-variable]
      int pos = 0;
          ^
```

### How to test
I have not test training after this change.

I assume it is safe since the variable is a simple scalar, is only ever written to, and those writing statements all involve only scalars. So I don't expect any side effects suddenly being different.

### Checklist

- [ ] I have tested the code manually
- [ ] I have run regression tests
- [ ] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
