### PR TITLE
Upgrade emsdk

### DIFF
--- a/.github/workflows/wasm-customized_marian-macos.yml
+++ b/.github/workflows/wasm-customized_marian-macos.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
     - name: Setup Emscripten toolchain
-      uses: mymindstorm/setup-emsdk@v9
+      uses: mymindstorm/setup-emsdk@v11
       with:
-          version: 2.0.9
+          version: 3.1.8
 
     - name: Verify Emscripten setup
       run: emcc -v

--- a/.github/workflows/wasm-customized_marian-ubuntu.yml
+++ b/.github/workflows/wasm-customized_marian-ubuntu.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
     - name: Setup Emscripten toolchain
-      uses: mymindstorm/setup-emsdk@v9
+      uses: mymindstorm/setup-emsdk@v11
       with:
-          version: 2.0.9
+          version: 3.1.8
 
     - name: Verify Emscripten setup
       run: emcc -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Enable loading SentencePiece vocabs from protobuf
 - Added a target-agnostic matrix multiply interface for wasm builds
 - Use target-agnostic matrix multiply interface for wasm builds and allow importing an implementation of this interface from separate wasm modules.
+- Upgraded emsdk version to 3.1.8
 
 ### Fixed
 - Fix AVX2 detection on macOS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,14 +288,16 @@ else(MSVC)
       set(DISABLE_PTHREAD_MEMGROWTH_WARNING -Wno-error=pthreads-mem-growth)
     endif(USE_THREADS)
     set(CMAKE_CXX_FLAGS                 "-std=c++11 ${PTHREAD_FLAG} ${CMAKE_GCC_FLAGS} -fPIC ${DISABLE_GLOBALLY} ${INTRINSICS}")
-    set(CMAKE_CXX_FLAGS_RELEASE         "-O3 -s WASM=1 -s ASSERTIONS=0 -s DISABLE_EXCEPTION_CATCHING=1 -s LLD_REPORT_UNDEFINED -s FORCE_FILESYSTEM=1 -s ALLOW_MEMORY_GROWTH=1 -g2 ${DISABLE_PTHREAD_MEMGROWTH_WARNING} -funroll-loops")
+    set(CMAKE_CXX_FLAGS_RELEASE         "-O3 -flto -funroll-loops -s DISABLE_EXCEPTION_CATCHING=1 ${DISABLE_PTHREAD_MEMGROWTH_WARNING}")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO  "${CMAKE_CXX_FLAGS_RELEASE} -g2 ${CMAKE_RDYNAMIC_FLAG}")
     # Disabling Pthreads + memory growth warning to be an error
     # Pthreads + memory growth causes JS accessing the wasm memory to be slow
     # https://github.com/WebAssembly/design/issues/1271
     list(APPEND ALL_WARNINGS ${DISABLE_PTHREAD_MEMGROWTH_WARNING})
 
     # use our customizations to the generated emscripted html and js resources
-    set(MARIAN_DECODER_EMSCRIPTEN_LINK_FLAGS "-s ERROR_ON_UNDEFINED_SYMBOLS=0 -s DECLARE_ASM_MODULE_EXPORTS=0 \
+    set(MARIAN_DECODER_EMSCRIPTEN_LINK_FLAGS "-s WASM=1 -s ASSERTIONS=0 -s DISABLE_EXCEPTION_CATCHING=1 -s LLD_REPORT_UNDEFINED -s ERROR_ON_UNDEFINED_SYMBOLS=0 -s FORCE_FILESYSTEM=1 \
+                                              -s ALLOW_MEMORY_GROWTH=1 ${DISABLE_PTHREAD_MEMGROWTH_WARNING} -s DECLARE_ASM_MODULE_EXPORTS=0 \
                                               -s EXPORTED_FUNCTIONS=[_main,_int8PrepareAFallback,_int8PrepareBFallback,_int8PrepareBFromTransposedFallback,_int8PrepareBFromQuantizedTransposedFallback,_int8PrepareBiasFallback,_int8MultiplyAndAddBiasFallback,_int8SelectColumnsOfBFallback] \
                                               --pre-js ${CMAKE_SOURCE_DIR}/wasm/pre-module.js \
                                               --post-js ${CMAKE_SOURCE_DIR}/wasm/post-module.js \

--- a/wasm/Dockerfile
+++ b/wasm/Dockerfile
@@ -1,4 +1,4 @@
-FROM emscripten/emsdk:2.0.9
+FROM emscripten/emsdk:3.1.8
 
 # Install specific version of CMake
 WORKDIR /usr

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -6,10 +6,10 @@
 For docker based builds, please refer [Docker Compilation Steps](#Docker-Compilation)
 
 1. Download and Install Emscripten using following instructions (skip this step if emsdk tool chain is already installed)
-    * Get the latest sdk: `git clone https://github.com/emscripten-core/emsdk.git`
+    * Get the sdk: `git clone https://github.com/emscripten-core/emsdk.git`
     * Enter the cloned directory: `cd emsdk`
-    * Install the lastest sdk tools: `./emsdk install latest`
-    * Activate the latest sdk tools: `./emsdk activate latest`
+    * Install the sdk tools: `./emsdk install 3.1.8`
+    * Activate the sdk tools: `./emsdk activate 3.1.8`
     * Activate path variables: `source ./emsdk_env.sh`
 
     `EMSDK` environment variable will point to the valid emsdk repo after executing the instructions above.


### PR DESCRIPTION
### Description

Fixes https://github.com/browsermt/marian-dev/issues/89

List of changes:
- Upgrade emsdk version from 2.0.9 to 3.1.8
- Updated cmake files to follow strict separation b/w compile and link flags

Added dependencies: none

### How to test
Followed [README](https://github.com/browsermt/marian-dev/tree/master/wasm#readme) instructions to run marian-decoder executable in Firefox browser to see translations in console logs.

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [x] I have updated CHANGELOG.md

@jelmervdl Thanks for inspiring this change.