### PR TITLE
Allow compilation without the presence of .git directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -141,20 +141,29 @@ target_compile_options(marian PRIVATE ${ALL_WARNINGS})
 # We set MARIAN_GIT_DIR to the appropriate path, depending on whether
 # ${CMAKE_CURRENT_SOURCE_DIR}/../.git is a directory or file.
 set(MARIAN_GIT_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../.git)
-if(NOT IS_DIRECTORY ${MARIAN_GIT_DIR}) # i.e., it's a submodule
-  file(READ ${MARIAN_GIT_DIR} MARIAN_GIT_DIR)
-  string(REGEX REPLACE "gitdir: (.*)\n" "\\1" MARIAN_GIT_DIR ${MARIAN_GIT_DIR})
-  if(NOT IS_ABSOLUTE ${MARIAN_GIT_DIR})
-    get_filename_component(MARIAN_GIT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../${MARIAN_GIT_DIR}" ABSOLUTE)
-  endif()
-endif(NOT IS_DIRECTORY ${MARIAN_GIT_DIR})
+if(NOT IS_DIRECTORY ${MARIAN_GIT_DIR} OR NOT EXISTS ${MARIAN_GIT_DIR})
+  message(WARNING "Could not find '${MARIAN_GIT_DIR}' to establish git revision. Continuing.")
+  execute_process(
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND bash -c "echo '#define GIT_REVISION \"unknown\"' > ${CMAKE_CURRENT_SOURCE_DIR}/common/git_revision.h"
+  )
+else()
+  if(NOT IS_DIRECTORY ${MARIAN_GIT_DIR}) # i.e., it's a submodule
+    file(READ ${MARIAN_GIT_DIR} MARIAN_GIT_DIR)
+    string(REGEX REPLACE "gitdir: (.*)\n" "\\1" MARIAN_GIT_DIR ${MARIAN_GIT_DIR})
+    if(NOT IS_ABSOLUTE ${MARIAN_GIT_DIR})
+      get_filename_component(MARIAN_GIT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../${MARIAN_GIT_DIR}" ABSOLUTE)
+    endif()
+  endif(NOT IS_DIRECTORY ${MARIAN_GIT_DIR})
 
-add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/common/git_revision.h
-  WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-  COMMAND git log -1 --pretty=format:\#define\ GIT_REVISION\ \"\%h\ \%ai\" > ${CMAKE_CURRENT_SOURCE_DIR}/common/git_revision.h
-  DEPENDS ${MARIAN_GIT_DIR}/logs/HEAD
-  VERBATIM
-)
+  add_custom_command(OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/common/git_revision.h
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMAND git log -1 --pretty=format:\#define\ GIT_REVISION\ \"\%h\ \%ai\" > ${CMAKE_CURRENT_SOURCE_DIR}/common/git_revision.h
+    DEPENDS ${MARIAN_GIT_DIR}/logs/HEAD
+    VERBATIM
+  )
+endif()
+
 add_custom_target(marian_version DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/common/git_revision.h)
 add_dependencies(marian marian_version) # marian must depend on it so that it gets created first
 # make sure all local dependencies are installed first before this is built


### PR DESCRIPTION
### Description

`src/CMakeLists.txt:145` does **not** allow compilation without the presence of a `.git` directory (or file).

This means that any `marian-dev` compile must always come from a `git clone` which is problematic for us as we are distributing `marian-dev` in a Python wheel package that, preferably, does not ship with `.git` directories.

List of changes:
- Changed `src/CMakeLists.txt`

### How to test

I have replaced the version with "unknown" when the git revision could not be established so that compilation may continue.

```bash
$ build/marian --version
v1.9.56 unknown
```
