### PR TITLE
no lax vector conversions for clang on ARM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,10 @@ if(USE_SIMD_UTILS)
   endif()
   if(MSVC)
     add_compile_options(/flax-vector-conversions)
-  else(MSVC)
+  elseif(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    # clang has a different default behaviour than gcc or msvc for lax-vector-conversions 
+    # and does not need the flag - it causes actually harm for some type casts - 
+    # see https://github.com/DLTcollab/sse2neon/pull/614
     add_compile_options(-flax-vector-conversions)
   endif(MSVC)
 endif(USE_SIMD_UTILS)


### PR DESCRIPTION
### Description
recent versions of sse2neon.h (included through simd_utils) do not build using clang and with `-flax-vector-conversions`.
clang builds (other than gcc) do not need this option though, therefore do not add it if clang is used.
Current code, when configured on ARM, configures with simd_utils, and `-flax-vector-conversions`.

List of changes:
- main CMakeLists.txt, only add `-flax-vector-conversions` if compiler is not clang

Added dependencies: none

### How to test
Try to build current code with clang on any ARM CPU against latest simd-utils. The build will fail.
With this patch applied, the build passes on ARM, with clang. 

### Checklist

- [x] I have tested the code manually
- [ ] I have run regression tests
- [x] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
