### PR TITLE
Don't pass `--no-as-needed` to clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,11 +331,11 @@ else(MSVC)
     list(APPEND ALL_WARNINGS -Wsuggest-override -Wno-int-in-bool-context)
   endif()
 
-  if(CMAKE_COMPILER_IS_GNUCC)
+  if(NOT CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     # these flags are not known to clang
     set(CMAKE_GCC_FLAGS "-Wl,--no-as-needed")
     set(CMAKE_RDYNAMIC_FLAG "-rdynamic")
-  endif(CMAKE_COMPILER_IS_GNUCC)
+  endif()
 
   if(COMPILE_WASM)
     if(USE_THREADS)


### PR DESCRIPTION
Error:
```
[ 37%] Building CXX object 3rd_party/marian-dev/src/3rd_party/intgemm/CMakeFiles/intgemm.dir/intgemm/intgemm.cc.o
clang: error: -Wl,--no-as-needed: 'linker' input unused [-Werror,-Wunused-command-line-argument]
make[2]: *** [3rd_party/marian-dev/src/3rd_party/intgemm/CMakeFiles/intgemm.dir/build.make:76: 3rd_party/marian-dev/src/3rd_party/intgemm/CMakeFiles/intgemm.dir/intgemm/intgemm.cc.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:800: 3rd_party/marian-dev/src/3rd_party/intgemm/CMakeFiles/intgemm.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```
