### PR TITLE
Add includes for intrinsics

### DIFF
--- a/src/3rd_party/faiss/VectorTransform.h
+++ b/src/3rd_party/faiss/VectorTransform.h
@@ -21,6 +21,12 @@
 #if defined(__APPLE__) && !defined(__arm64__)
 #include <x86intrin.h>
 #endif
+#if defined(__x86_64__) || defined(_M_X64) || defined(__i386__)
+#include <xmmintrin.h>
+#include <emmintrin.h>
+#include <pmmintrin.h>
+#endif
+
 
 
 namespace faiss {


### PR DESCRIPTION
### Description
When building for Android, these intrinsics are missing so things like `__m128` are not defined

```
 error: unknown type name '__m128'
  148 | static inline __m128 masked_read(int d, const float *x)
      |               ^
```

### Checklist

- [X] I have tested the code manually
- [ ] I have run regression tests
- [X] I have read and followed CONTRIBUTING.md
- [ ] I have updated CHANGELOG.md
